### PR TITLE
Require "orders" Okapi interface.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "home": "/orders",
     "hasSettings": true,
     "okapiInterfaces": {
+      "orders": "1.0",
       "acquisition_method": "1.0",
       "activation_status": "1.0",
       "adjustment": "1.0",


### PR DESCRIPTION
Will pull mod-orders into the "snapshot" build. Towards FOLIO-1531.