### PR TITLE
Replace stripes.intl.formatMessage with FormattedMessage

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,29 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
 
-/*
-  STRIPES-NEW-APP
-  Your app's settings pages are defined here.
-  The pages "general" and "some feature" are examples. Name them however you like.
-*/
-
 export default class OrdersSettings extends React.Component {
-  static propTypes = {
-    stripes: PropTypes.object,
-  }
-
   pages = [
     {
       route: 'general',
-      label: this.props.stripes.intl.formatMessage({ id: 'ui-orders.settings.general' }),
+      label: <FormattedMessage id="ui-orders.settings.general" />,
       component: GeneralSettings,
     },
     {
       route: 'somefeature',
-      label: this.props.stripes.intl.formatMessage({ id: 'ui-orders.settings.some-feature' }),
+      label: <FormattedMessage id="ui-orders.settings.some-feature" />,
       component: SomeFeatureSettings,
     },
   ];


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/stripes-core/pull/489

Retrieving the `intl` object from `this.context.intl` or the `stripes` god object (`stripes.intl`) is a deprecated pattern.

## Approach
Use `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` as often as possible, only falling back to `formatMessage()`, `formatDate()`, and `formatTime()` (accompanied by `injectIntl()`) when a bare string is absolutely necessary.