### PR TITLE
UIOR-83 Add PO Line - Vendor Ref Type required field

### DIFF
--- a/src/components/POLine/Vendor/VendorForm.js
+++ b/src/components/POLine/Vendor/VendorForm.js
@@ -7,6 +7,7 @@ import {
   TextArea,
   TextField,
 } from '@folio/stripes/components';
+import { requiredRefNumberType } from '../../Utils/Validate';
 import FieldRefNumberType from './FieldRefNumberType';
 
 class VendorForm extends Component {
@@ -20,6 +21,7 @@ class VendorForm extends Component {
             id="vendor_detail.ref_number"
             label={<FormattedMessage id="ui-orders.vendor.refNumber" />}
             name="vendor_detail.ref_number"
+            validate={[requiredRefNumberType]}
           />
         </Col>
         <Col xs={6}>

--- a/src/components/Utils/Validate.js
+++ b/src/components/Utils/Validate.js
@@ -15,6 +15,15 @@ export const requiredRefNumber = (value, allValues) => {
     : undefined;
 };
 
+// Field is required only if 'vendor_detail.ref_number_type' isn't empty
+export const requiredRefNumberType = (value, allValues) => {
+  const refNumberType = allValues.vendor_detail.ref_number_type;
+
+  return refNumberType && !value
+    ? REQUIRED
+    : undefined;
+};
+
 // Validation for Fields with type 'number' requires positive integer
 export const requiredPositiveNumber = (value) => {
   return value > 0

--- a/translations/ui-orders/en.json
+++ b/translations/ui-orders/en.json
@@ -503,7 +503,7 @@
   "vendor.refNumberType.librarysContinuation": "Library's continuation order number",
   "vendor.refNumberType.suppliersContinuation": "Supplier's continuation order",
   "vendor.refNumberType.suppliersUnique": "Supplier's unique order line reference number",
-  "vendor.refNumberType": "Vendor Ref Type*",
+  "vendor.refNumberType": "Vendor Ref Type",
   "vendor.vendor_status": "Status",
   "vendor.vendorAccount": "Vendor Account",
   "workflowStatus.closed": "Closed",


### PR DESCRIPTION
Purpose:
Vendor Ref Number and Vendor Ref Type are paired fields.
If Vendor Ref Number (free text field) is filled in, then Vendor Ref Type should be required.
If Vendor Ref Number is not filled in, then Vendor Ref Type should not be required.
![screenshot_11](https://user-images.githubusercontent.com/43407139/51103733-e2709980-17f4-11e9-91c8-a1b72bccacf7.png)
![screenshot_10](https://user-images.githubusercontent.com/43407139/51103734-e2709980-17f4-11e9-813d-22745df5a249.png)
