### PR TITLE
UIOR-99 Settings: Padding issue when adding a "Reason for closure"

### DIFF
--- a/src/settings/ClosingReasonsForm.js
+++ b/src/settings/ClosingReasonsForm.js
@@ -34,22 +34,23 @@ const renderReasons = ({ fields, removeReason, saveReason, meta: { pristine } })
   <Fragment>
     {fields.map((reason, index) => (
       <Row key={index}>
-        <Col xs={8}>
+        <Col xs={5}>
           <Field
             name={`${reason}.value`}
             type="text"
             component={TextField}
           />
         </Col>
-        <Col xs={1}>
+        <Col
+          xs={7}
+          lg={3}
+        >
           <Button
             disabled={pristine}
             onClick={() => saveReason(fields.get(index))}
           >
             <FormattedMessage id="ui-orders.settings.closingReasons.saveBtn" />
           </Button>
-        </Col>
-        <Col xs={1}>
           <Button
             buttonStyle="danger"
             onClick={() => {


### PR DESCRIPTION
Overview: Save and remove button are overlapping

How to reproduce:

Open settings
Choose orders settings
Choose "Closing Purchase Order Reasons"
Click "Add"
Actual Result:
'Save' button and 'Remove' button are overlapping

Expected Result:
There should be some padding between the buttons
https://issues.folio.org/browse/UIOR-99
![screenshot_14](https://user-images.githubusercontent.com/43407139/51113943-dbf21a00-1814-11e9-87bf-759f0a586cdb.png)
![screenshot_12](https://user-images.githubusercontent.com/43407139/51113944-dc8ab080-1814-11e9-8155-494329db9cf3.png)
![screenshot_13](https://user-images.githubusercontent.com/43407139/51113945-dc8ab080-1814-11e9-9a9e-c6f48ece9237.png)
