### PR TITLE
UIOR-115 Update the po_number schema to use camelCase

### DIFF
--- a/src/components/LayerCollection/LayerPOLine.js
+++ b/src/components/LayerCollection/LayerPOLine.js
@@ -175,7 +175,7 @@ class LayerPOLine extends Component {
     // Due to not perfect component hierarchy, the 'real' new PO Line goes only if orderId is not falsy
     if (orderId) {
       newObj.purchase_order_id = orderId;
-      newObj.po_line_number = `${order.po_number}-${lineSuffix}`;
+      newObj.po_line_number = `${order.poNumber}-${lineSuffix}`;
     }
 
     return newObj;

--- a/src/components/PurchaseOrder/PO.js
+++ b/src/components/PurchaseOrder/PO.js
@@ -240,7 +240,7 @@ class PO extends Component {
     const { location, history, match, mutator, resources, parentResources } = this.props;
     const order = get(resources, ['order', 'records', 0]);
     const orderId = get(order, 'id');
-    const orderNumber = get(order, 'po_number', '');
+    const orderNumber = get(order, 'poNumber', '');
     const poLines = get(order, 'po_lines', []);
     const workflowStatus = get(order, 'workflow_status');
     const hasLineItemsToReceive = poLines.filter(

--- a/src/components/PurchaseOrder/PODetails/PODetailsForm.js
+++ b/src/components/PurchaseOrder/PODetails/PODetailsForm.js
@@ -153,7 +153,7 @@ class PODetailsForm extends Component {
 
     if (value === '') {
       // setTimeout is required due to async nature of redux-form CHANGE field value event.
-      window.setTimeout(() => dispatch(change('po_number', generatedNumber)));
+      window.setTimeout(() => dispatch(change('poNumber', generatedNumber)));
     }
   }
 
@@ -182,7 +182,7 @@ class PODetailsForm extends Component {
               component={TextField}
               fullWidth
               label={<FormattedMessage id="ui-orders.orderDetails.poNumber" />}
-              name="po_number"
+              name="poNumber"
               disabled={!canUserEditOrderNumber}
               onBlur={this.fillBackGeneratedNumber}
             />

--- a/src/components/PurchaseOrder/PODetails/PODetailsView.js
+++ b/src/components/PurchaseOrder/PODetails/PODetailsView.js
@@ -36,7 +36,7 @@ class PODetailsView extends Component {
         <Col xs={6}>
           <KeyValue
             label={<FormattedMessage id="ui-orders.orderDetails.poNumber" />}
-            value={get(order, 'po_number')}
+            value={get(order, 'poNumber')}
           />
         </Col>
         <Col xs={6}>

--- a/src/components/PurchaseOrder/POForm.js
+++ b/src/components/PurchaseOrder/POForm.js
@@ -31,19 +31,19 @@ import { AdjustmentView } from './Adjustment';
 import { RenewalsForm } from './renewals';
 
 const throwError = () => {
-  const errorInfo = { po_number: <FormattedMessage id="ui-orders.errors.orderNumberIsNotValid" /> };
+  const errorInfo = { poNumber: <FormattedMessage id="ui-orders.errors.orderNumberIsNotValid" /> };
 
   throw errorInfo;
 };
 
 const asyncValidate = (values, dispatchRedux, props) => {
-  const { po_number: poNumber, numberPrefix = '', numberSuffix = '' } = values;
+  const { poNumber, numberPrefix = '', numberSuffix = '' } = values;
   const fullOrderNumber = `${numberPrefix}${poNumber}${numberSuffix}`.trim();
   const { parentMutator: { orderNumber: validator }, stripes: { store } } = props;
-  const orderNumberFieldIsDirty = isDirty('FormPO')(store.getState(), ['po_number']);
+  const orderNumberFieldIsDirty = isDirty('FormPO')(store.getState(), ['poNumber']);
 
   return orderNumberFieldIsDirty && poNumber
-    ? validator.POST({ po_number: fullOrderNumber })
+    ? validator.POST({ poNumber: fullOrderNumber })
       .catch(response => response.json()
         .catch(() => throwError())
         .then(() => throwError()))
@@ -82,9 +82,9 @@ class POForm extends Component {
 
     parentMutator.orderNumber.reset();
     parentMutator.orderNumber.GET()
-      .then(({ po_number: orderNumber }) => {
+      .then(({ poNumber: orderNumber }) => {
         if (!id) {
-          dispatch(change('po_number', orderNumber));
+          dispatch(change('poNumber', orderNumber));
         }
       });
   }
@@ -163,11 +163,11 @@ class POForm extends Component {
   render() {
     const { change, dispatch, initialValues, onCancel, stripes, parentResources } = this.props;
     const { sections } = this.state;
-    const generatedNumber = get(parentResources, 'orderNumber.records.0.po_number');
+    const generatedNumber = get(parentResources, 'orderNumber.records.0.poNumber');
     const formValues = getFormValues('FormPO')(stripes.store.getState());
     const isOngoing = formValues.order_type === ORDER_TYPE.ongoing;
     const firstMenu = this.getAddFirstMenu();
-    const orderNumber = get(initialValues, 'po_number', '');
+    const orderNumber = get(initialValues, 'poNumber', '');
     const paneTitle = initialValues.id
       ? <FormattedMessage id="ui-orders.order.paneTitle.edit" values={{ orderNumber }} />
       : <FormattedMessage id="ui-orders.paneMenu.createPurchaseOrder" />;
@@ -283,7 +283,7 @@ class POForm extends Component {
 }
 
 export default stripesForm({
-  asyncBlurFields: ['po_number'],
+  asyncBlurFields: ['poNumber'],
   asyncValidate,
   enableReinitialize: true,
   form: 'FormPO',

--- a/src/components/Utils/FilterConfig.js
+++ b/src/components/Utils/FilterConfig.js
@@ -16,9 +16,9 @@ const Filters = () => {
 };
 
 const SearchableIndexes = [
-  { label: 'All', value: 'all', makeQuery: term => `(id="${term}*" or po_number="${term}*" or vendor="${term}*" or assigned_to="${term}*")` },
+  { label: 'All', value: 'all', makeQuery: term => `(id="${term}*" or poNumber="${term}*" or vendor="${term}*" or assigned_to="${term}*")` },
   { label: 'ID', value: 'id', makeQuery: term => `(id="${term}*")` },
-  { label: 'PO Number', value: 'po_number', makeQuery: term => `(po_number="${term}*")` },
+  { label: 'PO Number', value: 'poNumber', makeQuery: term => `(poNumber="${term}*")` },
   { label: 'Vendor', value: 'vendor', makeQuery: term => `(vendor="${term}*")` },
   { label: 'Assigned To', value: 'assigned_to', makeQuery: term => `(assigned_to="${term}*")` },
 ];

--- a/src/components/Utils/orderResource.js
+++ b/src/components/Utils/orderResource.js
@@ -29,10 +29,10 @@ export const updateOrderResource = (order, mutator, changedProps) => {
 
 export const createOrderResource = (order, mutator) => {
   const clonedOrder = cloneDeep(order);
-  const { numberPrefix = '', numberSuffix = '', po_number: orderNumber = '' } = clonedOrder;
-  const fullOrderNumber = `${numberPrefix}${orderNumber}${numberSuffix}`.trim();
+  const { numberPrefix = '', numberSuffix = '', poNumber = '' } = clonedOrder;
+  const fullOrderNumber = `${numberPrefix}${poNumber}${numberSuffix}`.trim();
 
-  clonedOrder.po_number = fullOrderNumber || undefined;
+  clonedOrder.poNumber = fullOrderNumber || undefined;
 
   return saveOrder(clonedOrder, mutator);
 };
@@ -42,7 +42,7 @@ export const cloneOrder = (order, mutator, line) => {
 
   delete clonedOrder.id;
   delete clonedOrder.adjustment;
-  delete clonedOrder.po_number;
+  delete clonedOrder.poNumber;
   delete clonedOrder.workflow_status;
   if (line) {
     delete line.purchase_order_id;

--- a/src/routes/Main.js
+++ b/src/routes/Main.js
@@ -207,7 +207,7 @@ class Main extends Component {
     } = this.props;
     const users = get(resources, 'users.records', []);
     const resultsFormatter = {
-      'po_number': order => get(order, 'po_number', ''),
+      'poNumber': order => get(order, 'poNumber', ''),
       'created': order => <FolioFormattedTime dateString={get(order, 'metadata.createdDate')} />,
       'notes': order => get(order, 'notes', []).join(', '),
       'assigned_to': order => {
@@ -231,7 +231,7 @@ class Main extends Component {
           objectName="order"
           baseRoute={packageInfo.stripes.route}
           filterConfig={filterConfig}
-          visibleColumns={['po_number', 'workflow_status', 'created', 'notes', 'assigned_to']}
+          visibleColumns={['poNumber', 'workflow_status', 'created', 'notes', 'assigned_to']}
           resultsFormatter={resultsFormatter}
           viewRecordComponent={Panes}
           editRecordComponent={POForm}
@@ -251,9 +251,9 @@ class Main extends Component {
           stripes={stripes}
           showSingleResult={showSingleResult}
           browseOnly={browseOnly}
-          columnWidths={{ po_number: '120px' }}
+          columnWidths={{ poNumber: '120px' }}
           columnMapping={{
-            po_number: <FormattedMessage id="ui-orders.order.po_number" />,
+            poNumber: <FormattedMessage id="ui-orders.order.po_number" />,
             created: <FormattedMessage id="ui-orders.order.created" />,
             notes: <FormattedMessage id="ui-orders.order.notes" />,
             assigned_to: <FormattedMessage id="ui-orders.order.assigned_to" />,

--- a/test/bigtest/interactors/orders.js
+++ b/test/bigtest/interactors/orders.js
@@ -9,7 +9,7 @@ export default interactor(class OrdersInteractor {
   static defaultScope = '[data-test-order-instances]';
 
   hasCreateOrderButton = isPresent('#clickable-neworder');
-  hasPONumberField = isPresent('[name="po_number"]');
+  hasPONumberField = isPresent('[name="poNumber"]');
   hasVendorNameField = isPresent('#vendor_name');
   hasCreatedByField = isPresent('#created_by_name');
 

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -24,6 +24,6 @@ export default function config() {
   this.get('/material-types');
 
   this.get(ORDER_NUMBER_API, () => {
-    return { po_number: '10001' };
+    return { poNumber: '10001' };
   });
 }

--- a/test/bigtest/network/factories/order.js
+++ b/test/bigtest/network/factories/order.js
@@ -2,7 +2,7 @@ import { Factory, faker } from '@bigtest/mirage';
 
 export default Factory.extend({
   id: () => faker.random.uuid(),
-  po_number: (id) => `${id}${faker.random.alphaNumeric()}${faker.random.alphaNumeric()}${faker.random.alphaNumeric()}`,
+  poNumber: (id) => `${id}${faker.random.alphaNumeric()}${faker.random.alphaNumeric()}${faker.random.alphaNumeric()}`,
   metadata: () => ({
     createdDate: faker.date.past(),
   }),

--- a/test/bigtest/tests/details-order-test.js
+++ b/test/bigtest/tests/details-order-test.js
@@ -21,7 +21,7 @@ describe('OrderDetailsPage', () => {
   });
 
   it('displays the order number in the pane header', () => {
-    expect(OrderDetailsPage.title).to.include(order.po_number);
+    expect(OrderDetailsPage.title).to.include(order.poNumber);
   });
 
   describe('clicking on edit', () => {


### PR DESCRIPTION
FOLIO naming conventions for schemas dictate that camelCase is used for field names instead of under_score notation.
https://issues.folio.org/browse/UIOR-115
Should be merged after
https://issues.folio.org/browse/MODORDERS-130
https://github.com/folio-org/acq-models/pull/80
https://github.com/folio-org/mod-orders-storage/pull/73
https://github.com/folio-org/mod-orders/pull/84