### PR TITLE
UIOR-117 several fixes

### DIFF
--- a/src/components/LayerCollection/LayerPOLine.js
+++ b/src/components/LayerCollection/LayerPOLine.js
@@ -156,8 +156,9 @@ class LayerPOLine extends Component {
   }
 
   getCreatePOLIneInitialValues() {
-    const { match } = this.props;
+    const { match, order = {} } = this.props;
     const orderId = get(match, 'params.id');
+    const lineSuffix = get(order, 'po_lines', []).length + 1;
 
     const newObj = {
       source: {
@@ -171,8 +172,10 @@ class LayerPOLine extends Component {
       },
     };
 
+    // Due to not perfect component hierarchy, the 'real' new PO Line goes only if orderId is not falsy
     if (orderId) {
       newObj.purchase_order_id = orderId;
+      newObj.po_line_number = `${order.po_number}-${lineSuffix}`;
     }
 
     return newObj;

--- a/src/components/POLine/POLineDetails/POLineDetailsForm.js
+++ b/src/components/POLine/POLineDetails/POLineDetailsForm.js
@@ -13,17 +13,13 @@ import {
   TextField,
 } from '@folio/stripes/components';
 
+import { required } from '../../Utils/Validate';
 import FolioFormattedTime from '../../FolioFormattedTime';
 import FieldPaymentStatus from './FieldPaymentStatus';
 import FieldReceiptStatus from './FieldReceiptStatus';
 import FieldOrderFormat from './FieldOrderFormat';
 import FieldAcquisitionMethod from './FieldAcquisitionMethod';
 // import FieldSource from './FieldSource';
-
-const LINE_NUMBER_REGEXP = RegExp('^[a-zA-Z0-9]{5,16}-[0-9]{1,3}$');
-const isValidLineNumber = (value) => {
-  return LINE_NUMBER_REGEXP.test(value) ? undefined : 'must match "^[a-zA-Z0-9]{5,16}-[0-9]{1,3}$"';
-};
 
 class POLineDetailsForm extends Component {
   static propTypes = {
@@ -59,7 +55,7 @@ class POLineDetailsForm extends Component {
               label={<FormattedMessage id="ui-orders.poLine.poLineNumber" />}
               name="po_line_number"
               type="text"
-              validate={isValidLineNumber}
+              validate={required}
             />
           </Col>
           <Col xs={6}>

--- a/src/components/PurchaseOrder/PO.js
+++ b/src/components/PurchaseOrder/PO.js
@@ -33,9 +33,10 @@ import {
   updateOrderResource,
 } from '../Utils/orderResource';
 import {
-  MODULE_ORDERS,
-  CONFIG_LINES_LIMIT,
   CONFIG_CLOSING_REASONS,
+  CONFIG_LINES_LIMIT,
+  LINES_LIMIT_DEFAULT,
+  MODULE_ORDERS,
 } from '../Utils/const';
 import { ORDER_TYPE } from './PODetails/FieldOrderType';
 import CloseOrderModal from './CloseOrder';
@@ -52,6 +53,7 @@ class PO extends Component {
     order: {
       type: 'okapi',
       path: ORDER_DETAIL_API,
+      throwErrors: false,
     },
     poLine: {
       type: 'okapi',
@@ -159,7 +161,7 @@ class PO extends Component {
 
   onAddPOLine = () => {
     const { resources } = this.props;
-    const linesLimit = Number(get(resources, ['linesLimit', 'records', '0', 'value'], '1'));
+    const linesLimit = Number(get(resources, ['linesLimit', 'records', '0', 'value'], LINES_LIMIT_DEFAULT));
     const poLines = get(resources, ['order', 'records', '0', 'po_lines'], []);
 
     if (linesLimit <= poLines.length) {

--- a/src/components/PurchaseOrder/PODetails/PODetailsForm.js
+++ b/src/components/PurchaseOrder/PODetails/PODetailsForm.js
@@ -26,7 +26,7 @@ import css from './PODetailsForm.css';
 
 class PODetailsForm extends Component {
   static propTypes = {
-    generatedNumber: PropTypes.string.isRequired,
+    generatedNumber: PropTypes.string,
     orderNumberSetting: PropTypes.object.isRequired,
     formValues: PropTypes.object,
     stripes: PropTypes.object,

--- a/src/components/PurchaseOrder/POForm.js
+++ b/src/components/PurchaseOrder/POForm.js
@@ -68,6 +68,7 @@ class POForm extends Component {
   componentDidMount() {
     const { initialValues: { id }, change, dispatch, parentMutator } = this.props;
 
+    parentMutator.orderNumber.reset();
     parentMutator.orderNumber.GET()
       .then(({ po_number: orderNumber }) => {
         if (!id) {

--- a/src/components/Utils/const.js
+++ b/src/components/Utils/const.js
@@ -5,3 +5,4 @@ export const CONFIG_CLOSING_REASONS = 'closing-reasons';
 export const CONFIG_LINES_LIMIT = 'poLines-limit';
 export const CONFIG_ORDER_NUMBER = 'orderNumber';
 export const SOURCE_FOLIO_CODE = 'FOLIO';
+export const LINES_LIMIT_DEFAULT = 1;

--- a/src/routes/Main.js
+++ b/src/routes/Main.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
-import {
-  filters2cql,
-  Callout,
-} from '@folio/stripes/components';
+import { Callout } from '@folio/stripes/components';
 import { SearchAndSort } from '@folio/stripes/smart-components';
 
 import packageInfo from '../../package';
@@ -17,7 +14,7 @@ import {
 } from '../components/Utils/const';
 import Panes from '../components/Panes';
 import { POForm } from '../components/PurchaseOrder';
-import { Filters, SearchableIndexes } from '../components/Utils/FilterConfig';
+import { Filters } from '../components/Utils/FilterConfig';
 import FolioFormattedTime from '../components/FolioFormattedTime';
 import { createOrderResource } from '../components/Utils/orderResource';
 import {
@@ -31,7 +28,6 @@ import {
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
 const filterConfig = Filters();
-const searchableIndexes = SearchableIndexes;
 
 class Main extends Component {
   static manifest = Object.freeze({
@@ -51,67 +47,6 @@ class Main extends Component {
       records: 'purchase_orders',
       recordsRequired: '%{resultCount}',
       perRequest: RESULT_COUNT_INCREMENT,
-      GET: {
-        params: {
-          query: (...args) => {
-            /*
-              This code is not DRY as it is copied from makeQueryFunction in stripes-components.
-              This is necessary, as makeQueryFunction only referneces query paramaters as a data source.
-              STRIPES-480 is intended to correct this and allow this query function to be replace with a call
-              to makeQueryFunction.
-              https://issues.folio.org/browse/STRIPES-480
-            */
-            const resourceData = args[2];
-            const sortMap = {
-              'ID': 'id',
-              'PO Number': 'po_number',
-              'Created By': 'created_by',
-              'Comments': 'comments',
-              'Assigned To': 'assigned_to',
-            };
-
-            const index = resourceData.query.qindex ? resourceData.query.qindex : 'all';
-            const searchableIndex = searchableIndexes.find(idx => idx.value === index);
-
-            let cql = searchableIndex.makeQuery(resourceData.query.query);
-            const filterCql = filters2cql(filterConfig, resourceData.query.filters);
-
-            if (filterCql) {
-              if (cql) {
-                cql = `(${cql}) and ${filterCql}`;
-              } else {
-                cql = filterCql;
-              }
-            }
-
-            const { sort } = resourceData.query;
-
-            if (sort) {
-              const sortIndexes = sort.split(',').map((sort1) => {
-                let reverse = false;
-
-                if (sort1.startsWith('-')) {
-                  // eslint-disable-next-line no-param-reassign
-                  sort1 = sort1.substr(1);
-                  reverse = true;
-                }
-                let sortIndex = sortMap[sort1] || sort1;
-
-                if (reverse) {
-                  sortIndex = `${sortIndex.replace(' ', '/sort.descending ')}/sort.descending`;
-                }
-
-                return sortIndex;
-              });
-
-              cql += ` sortby ${sortIndexes.join(' ')}`;
-            }
-
-            return cql;
-          },
-        },
-        staticFallback: { params: {} },
-      },
     },
     vendors: {
       type: 'okapi',
@@ -316,6 +251,7 @@ class Main extends Component {
           stripes={stripes}
           showSingleResult={showSingleResult}
           browseOnly={browseOnly}
+          columnWidths={{ po_number: '120px' }}
           columnMapping={{
             po_number: <FormattedMessage id="ui-orders.order.po_number" />,
             created: <FormattedMessage id="ui-orders.order.created" />,

--- a/src/settings/POLinesLimitForm.js
+++ b/src/settings/POLinesLimitForm.js
@@ -10,8 +10,9 @@ import {
   Row,
   TextField,
 } from '@folio/stripes/components';
-
 import stripesForm from '@folio/stripes/form';
+
+import { LINES_LIMIT_DEFAULT } from '../components/Utils/const';
 
 const validateLimit = value => {
   return value === '' || ((value > 0) && (Number.isInteger(+value)) && (value < 1000))
@@ -54,7 +55,7 @@ const POLinesLimitForm = props => {
                 component={TextField}
                 label={<FormattedMessage id="ui-orders.settings.setPOLInesLimit" />}
                 name="value"
-                placeholder="999"
+                placeholder={LINES_LIMIT_DEFAULT}
                 type="number"
                 validate={validateLimit}
               />

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -24,6 +24,6 @@ export default function config() {
   this.get('/material-types');
 
   this.get(ORDER_NUMBER_API, () => {
-    return { po_number: 10001 };
+    return { po_number: '10001' };
   });
 }


### PR DESCRIPTION
* in Settings for PO Lines limit show placeholder as 1 instead of 999;
* in Orders list don't show alert with errors if clicked on order with invalid id;
* in Create PO Line fill po_line_number as _(orderNumber)-(orderLinesCount+1)_;
* in Create/Edit PO Line change validation of po_line_number to simple required;
* in Edit Order fetch fresh generated PO Number from orderNumber API;
* in Orders List added _columnWidths_ property to SearchAndSort to make po_number column wider;
* in Orders List removed unused code for use filtering on back-end, since API don't support it for now.