### PR TITLE
UIOR-104 add missing permissions to ui-orders package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
         "description": "Get a collection of vendors"
       },
       {
-        "permissionName": "orders.collection.get",
-        "displayName": "orders - get orders collection",
-        "description": "Get orders collection"
-      },
-      {
         "permissionName": "users.collection.get",
         "displayName": "users collection get",
         "description": "Get a collection of user records"
+      },
+      {
+        "permissionName": "orders.collection.get",
+        "displayName": "orders - get orders collection",
+        "description": "Get orders collection"
       },
       {
         "permissionName": "orders.item.post",
@@ -70,6 +70,11 @@
         "permissionName": "orders.item.delete",
         "displayName": "orders - delete an existing order",
         "description": "Delete an existing order"
+      },
+      {
+        "permissionName": "orders.po-lines.collection.get",
+        "displayName": "Orders - get collection of PO lines",
+        "description": "Get collection of PO lines"
       },
       {
         "permissionName": "orders.po-lines.item.post",
@@ -102,6 +107,16 @@
         "description": "Validate a PO Number"
       },
       {
+        "permissionName": "orders.receiving.collection.post",
+        "displayName": "Orders - Receive items",
+        "description": "Receive items spanning one or more po_lines in this order"
+      },
+      {
+        "permissionName": "orders.check-in.collection.post",
+        "displayName": "Orders - Check-in items",
+        "description": "Check-in items spanning one or more po_lines in this order"
+      },
+      {
         "permissionName": "orders.receiving-history.collection.get",
         "displayName": "Orders - Receiving history",
         "description": "Get receiving history matching the provided criteria"
@@ -116,11 +131,14 @@
           "orders.item.get",
           "orders.item.put",
           "orders.item.delete",
+          "orders.po-lines.collection.get",
           "orders.po-lines.item.post",
           "orders.po-lines.item.get",
           "orders.po-lines.item.put",
           "orders.po-lines.item.delete",
           "orders.po-number.item.post",
+          "orders.receiving.collection.post",
+          "orders.check-in.collection.post",
           "orders.receiving-history.collection.get"
         ]
       },


### PR DESCRIPTION
Fix UIOR-104 Orders: No Functioning Permission for Access to Orders App

## Purpose
Some permissions were added to mod-orders description.
https://issues.folio.org/browse/UIOR-104

## Approach
I've added missing permissions to package.json

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
