### PR TITLE
UIOR-119 Once a prefix or suffix is selected you cannot remove them

### DIFF
--- a/src/components/PurchaseOrder/PODetails/PODetailsForm.js
+++ b/src/components/PurchaseOrder/PODetails/PODetailsForm.js
@@ -22,6 +22,8 @@ import NotesForm from '../../NotesForm';
 import { required } from '../../Utils/Validate';
 import FolioFormattedTime from '../../FolioFormattedTime';
 import FieldOrderType from './FieldOrderType';
+import { addEmptyOption } from '../util';
+
 import css from './PODetailsForm.css';
 
 class PODetailsForm extends Component {
@@ -172,8 +174,7 @@ class PODetailsForm extends Component {
               component={Select}
               label={<FormattedMessage id="ui-orders.orderDetails.orderNumberPrefix" />}
               name="numberPrefix"
-              placeholder=" "
-              dataOptions={selectedPrefixes}
+              dataOptions={addEmptyOption(selectedPrefixes)}
               disabled={isExistingOrder}
             />
           </Col>
@@ -192,8 +193,7 @@ class PODetailsForm extends Component {
               component={Select}
               label={<FormattedMessage id="ui-orders.orderDetails.orderNumberSuffix" />}
               name="numberSuffix"
-              placeholder=" "
-              dataOptions={selectedSuffixes}
+              dataOptions={addEmptyOption(selectedSuffixes)}
               disabled={isExistingOrder}
             />
           </Col>

--- a/src/components/PurchaseOrder/util.js
+++ b/src/components/PurchaseOrder/util.js
@@ -32,3 +32,10 @@ export const isReceiveAvailableForOrder = (order = {}) => {
 
   return hasLineItemsToReceive && isWorkflowStatusOpen(order);
 };
+
+const EMPTY_OPTION = {
+  label: '',
+  value: '',
+};
+
+export const addEmptyOption = (options = []) => [EMPTY_OPTION, ...options];

--- a/test/bigtest/interactors/order-edit-page.js
+++ b/test/bigtest/interactors/order-edit-page.js
@@ -2,7 +2,13 @@ import {
   interactor,
   text,
   isPresent,
+  value,
 } from '@bigtest/interactor';
+
+@interactor class SuffixSelect {
+  static defaultScope = 'select[name="numberSuffix"]';
+  value = value();
+}
 
 export default interactor(class OrderEditPage {
   static defaultScope = '[data-test-form-page]';
@@ -13,4 +19,5 @@ export default interactor(class OrderEditPage {
   }
 
   title = text('[class*=paneTitleLabel---]');
+  suffixSelect = new SuffixSelect();
 });

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -37,4 +37,17 @@ export default function config() {
   });
 
   this.get('/locations');
+
+  this.get('/configurations/entries', (_, { queryParams }) => {
+    return queryParams && queryParams.query === '(module=ORDERS and configName=orderNumber)'
+      ? {
+        configs: [{
+          id: '7c7c5a09-d465-4642-889a-8a0b351d7b15',
+          module: 'ORDERS',
+          configName: 'orderNumber',
+          enabled: true,
+          value: '{"canUserEditOrderNumber":false,"selectedPrefixes":["PP"],"prefixes":["PP1","PP2","PP3","PP"],"selectedSuffixes":["SS"],"suffixes":["SS1","SS2","SS"]}',
+        }],
+      } : { configs: [] };
+  });
 }

--- a/test/bigtest/tests/create-order-test.js
+++ b/test/bigtest/tests/create-order-test.js
@@ -3,11 +3,13 @@ import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
 import OrdersInteractor from '../interactors/orders';
+import OrderEditPage from '../interactors/order-edit-page';
 
 describe('Create order', () => {
   setupApplication();
 
   const orders = new OrdersInteractor();
+  const form = new OrderEditPage();
 
   beforeEach(function () {
     return this.visit('/orders?layer=create&sort=id', () => {
@@ -25,5 +27,30 @@ describe('Create order', () => {
 
   it('has a created by field', () => {
     expect(orders.hasCreatedByField).to.be.true;
+  });
+
+  it('suffix select is available', () => {
+    expect(form.suffixSelect.value).to.be.equal('');
+  });
+
+  describe('suffix could be selected', () => {
+    beforeEach(async () => {
+      await form.suffixSelect.select('SS');
+    });
+
+    it('suffix is changed to "SS"', () => {
+      expect(form.suffixSelect.value).to.be.equal('SS');
+    });
+  });
+
+  describe('suffix could be changed back to empty value', () => {
+    beforeEach(async () => {
+      await form.suffixSelect.select('SS');
+      await form.suffixSelect.select('');
+    });
+
+    it('suffix is changed back to blank', () => {
+      expect(form.suffixSelect.value).to.be.equal('');
+    });
   });
 });

--- a/translations/ui-orders/en.json
+++ b/translations/ui-orders/en.json
@@ -24,6 +24,7 @@
   "brd.renewConfirmation": "Renew Confirmation",
   "brd.successfulRenewal": "Item successfully renewed",
   "button.addLine": "Add PO Line",
+  "button.edit": "Edit",
   "button.remove": "Remove",
   "buttons.line.close": "Close",
   "buttons.line.closeDialog": "Close New Line Dialog",


### PR DESCRIPTION
## Purpose
To provide ability de-select suffix or prefix
https://issues.folio.org/browse/UIOR-119

## Approach
Add empty option to suffixes or prefixes.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
