### PR TITLE
UIOR-111 remove PO Line number from Create form

### DIFF
--- a/src/components/POLine/POLineDetails/POLineDetailsForm.js
+++ b/src/components/POLine/POLineDetails/POLineDetailsForm.js
@@ -43,15 +43,17 @@ class POLineDetailsForm extends Component {
       <Fragment>
         <Row>
           <Col xs={6}>
-            <Field
-              component={TextField}
-              disabled
-              fullWidth
-              id="po_line_number"
-              label={<FormattedMessage id="ui-orders.poLine.poLineNumber" />}
-              name="po_line_number"
-              type="text"
-            />
+            {poLine.id && (
+              <Field
+                component={TextField}
+                disabled
+                fullWidth
+                id="po_line_number"
+                label={<FormattedMessage id="ui-orders.poLine.poLineNumber" />}
+                name="po_line_number"
+                type="text"
+              />
+            )}
           </Col>
           <Col xs={6}>
             <FieldAcquisitionMethod />


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIOR-111
It just seems unnecessary to have it disabled on the screen. When editing it could be valuable to see it as there will be a number in there but during creation it seems redundant.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
