### PR TITLE
UIREC-14 Receive History access button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-orders
 
+## [1.3.0] - Unreleased
+* UIREC-14 Receiving: Access "Receiving History" for a PO
+
 ## [1.2.0](https://github.com/folio-org/ui-orders/tree/v1.2.0) (2019-02-22)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v1.1.1...v1.2.0)
 

--- a/src/components/Receiving/ReceivingHistory.js
+++ b/src/components/Receiving/ReceivingHistory.js
@@ -1,0 +1,74 @@
+import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types';
+
+import {
+  IconButton,
+  Pane,
+  PaneMenu,
+  Paneset,
+} from '@folio/stripes/components';
+
+import ReceivingLinks, { RECEIVING_HISTORY } from './ReceivingLinks';
+
+class ReceivingHistory extends Component {
+  static manifest = Object.freeze({
+    query: {
+      initialValue: {
+        query: '',
+      },
+    },
+  })
+
+  static propTypes = {
+    location: ReactRouterPropTypes.location,
+    mutator: PropTypes.object,
+  }
+
+  onCloseReceiving = () => {
+    const { location, mutator } = this.props;
+
+    mutator.query.update({
+      _path: location.pathname.replace(RECEIVING_HISTORY, ''),
+    });
+  }
+
+  getFirstMenu = () => (
+    <PaneMenu>
+      <FormattedMessage id="ui-orders.buttons.line.close">
+        {(title) => (
+          <IconButton
+            ariaLabel={title}
+            data-test-close-button
+            icon="times"
+            onClick={this.onCloseReceiving}
+          />
+        )}
+      </FormattedMessage>
+    </PaneMenu>
+  );
+
+  render() {
+    const { mutator, location } = this.props;
+
+    return (
+      <div data-test-receiving-history>
+        <Paneset>
+          <Pane
+            defaultWidth="fill"
+            paneTitle={(
+              <ReceivingLinks
+                location={location}
+                mutator={mutator}
+              />
+            )}
+            firstMenu={this.getFirstMenu()}
+          />
+        </Paneset>
+      </div>
+    );
+  }
+}
+
+export default ReceivingHistory;

--- a/src/components/Receiving/ReceivingLinks.js
+++ b/src/components/Receiving/ReceivingLinks.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import { FormattedMessage } from 'react-intl';
+import ReactRouterPropTypes from 'react-router-prop-types';
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+  ButtonGroup,
+} from '@folio/stripes/components';
+
+export const RECEIVING_ITEMS = '/receiving';
+export const RECEIVING_HISTORY = '/receiving-history';
+
+class ReceivingLinks extends Component {
+  static propTypes = {
+    mutator: PropTypes.object.isRequired,
+    location: ReactRouterPropTypes.location.isRequired,
+
+  }
+
+  getButtonStyle = (pathEnding) => {
+    const { location } = this.props;
+
+    return location.pathname.endsWith(pathEnding)
+      ? 'primary'
+      : 'default';
+  };
+
+  goToHistory = () => {
+    this.handleNavigate(RECEIVING_ITEMS, RECEIVING_HISTORY);
+  }
+
+  goToItems = () => {
+    this.handleNavigate(RECEIVING_HISTORY, RECEIVING_ITEMS);
+  }
+
+  handleNavigate = (from, to) => {
+    const { location, mutator } = this.props;
+
+    if (location.pathname.endsWith(to)) {
+      return;
+    }
+
+    mutator.query.update({
+      _path: location.pathname.replace(from, to),
+    });
+  };
+
+  render() {
+    return (
+      <ButtonGroup>
+        <Button
+          buttonStyle={this.getButtonStyle(RECEIVING_ITEMS)}
+          marginBottom0
+          onClick={this.goToItems}
+        >
+          <FormattedMessage id="ui-orders.receiving.links.items" />
+        </Button>
+        <Button
+          buttonStyle={this.getButtonStyle(RECEIVING_HISTORY)}
+          marginBottom0
+          onClick={this.goToHistory}
+        >
+          <FormattedMessage id="ui-orders.receiving.links.history" />
+        </Button>
+      </ButtonGroup>
+    );
+  }
+}
+
+export default ReceivingLinks;

--- a/src/components/Receiving/ReceivingList.js
+++ b/src/components/Receiving/ReceivingList.js
@@ -27,6 +27,7 @@ import {
   PIECE_STATUS_EXPECTED,
   PIECE_STATUS_RECEIVED,
 } from './const';
+import ReceivingLinks from './ReceivingLinks';
 
 import css from './ReceivingList.css';
 
@@ -97,7 +98,6 @@ class ReceivingList extends Component {
             ariaLabel={title}
             data-test-close-button
             icon="times"
-            id="clickable-close-new-line-dialog"
             onClick={this.onCloseReceiving}
           />
         )}
@@ -131,7 +131,7 @@ class ReceivingList extends Component {
   }
 
   render() {
-    const { resources } = this.props;
+    const { resources, mutator, location } = this.props;
     const receivingList = get(resources, ['receiving_history', 'records'], []);
     const uniqReceivingList = uniqBy(receivingList, 'poLineId');
     const resultsFormatter = {
@@ -163,7 +163,12 @@ class ReceivingList extends Component {
         <Paneset>
           <Pane
             defaultWidth="fill"
-            paneTitle={<FormattedMessage id="ui-orders.receiving.paneTitle" />}
+            paneTitle={(
+              <ReceivingLinks
+                location={location}
+                mutator={mutator}
+              />
+            )}
             firstMenu={this.getFirstMenu()}
           >
             <Row

--- a/src/components/Receiving/index.js
+++ b/src/components/Receiving/index.js
@@ -1,3 +1,13 @@
-import Receiving from './ReceivingList';
+import ReceivingHistory from './ReceivingHistory';
+import ReceivingList from './ReceivingList';
+import {
+  RECEIVING_HISTORY,
+  RECEIVING_ITEMS,
+} from './ReceivingLinks';
 
-export default Receiving;
+export {
+  RECEIVING_HISTORY,
+  RECEIVING_ITEMS,
+  ReceivingHistory,
+  ReceivingList,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,20 @@ import { stripesShape } from '@folio/stripes/core';
 
 import Main from './routes/Main';
 import OrdersSettings from './settings/OrdersSettings';
-import Receiving from './components/Receiving';
+import {
+  RECEIVING_HISTORY,
+  RECEIVING_ITEMS,
+  ReceivingHistory,
+  ReceivingList,
+} from './components/Receiving';
 
 /*
   STRIPES-NEW-APP
   This is the main entry point into your new app.
 */
+
+const ORDER_DETAIL_URL = '/orders/view/:id';
+const LINE_DETAIL_URL = `${ORDER_DETAIL_URL}/po-line/view/:lineId`;
 
 class Orders extends Component {
   static propTypes = {
@@ -27,7 +35,8 @@ class Orders extends Component {
   constructor(props, context) {
     super(props, context);
     this.connectedApp = props.stripes.connect(Main);
-    this.connectedReceiving = props.stripes.connect(Receiving);
+    this.connectedReceiving = props.stripes.connect(ReceivingList);
+    this.connectedReceivingHistory = props.stripes.connect(ReceivingHistory);
   }
 
   render() {
@@ -41,12 +50,22 @@ class Orders extends Component {
       <Switch>
         <Route
           exact
-          path="/orders/view/:id/po-line/view/:lineId/receiving"
+          path={`${LINE_DETAIL_URL}${RECEIVING_HISTORY}`}
+          render={props => <this.connectedReceivingHistory {...props} stripes={stripes} />}
+        />
+        <Route
+          exact
+          path={`${LINE_DETAIL_URL}${RECEIVING_ITEMS}`}
           render={props => <this.connectedReceiving {...props} stripes={stripes} />}
         />
         <Route
           exact
-          path="/orders/view/:id/receiving"
+          path={`${ORDER_DETAIL_URL}${RECEIVING_HISTORY}`}
+          render={props => <this.connectedReceivingHistory {...props} stripes={stripes} />}
+        />
+        <Route
+          exact
+          path={`${ORDER_DETAIL_URL}${RECEIVING_ITEMS}`}
           render={props => <this.connectedReceiving {...props} stripes={stripes} />}
         />
         <Route

--- a/test/bigtest/interactors/receiving-history-page.js
+++ b/test/bigtest/interactors/receiving-history-page.js
@@ -1,0 +1,14 @@
+import {
+  interactor,
+  is,
+} from '@bigtest/interactor';
+
+@interactor class CloseButton {
+  static defaultScope = '[data-test-close-button]';
+  isButton = is('button');
+}
+
+export default interactor(class ReceivingHistoryPage {
+  static defaultScope = '[data-test-receiving-history]';
+  closeButton = new CloseButton();
+});

--- a/test/bigtest/tests/receiving-history-test.js
+++ b/test/bigtest/tests/receiving-history-test.js
@@ -1,0 +1,45 @@
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import OrderDetailsPage from '../interactors/order-details-page';
+import ReceivingHistoryPage from '../interactors/receiving-history-page';
+import { WORKFLOW_STATUS } from '../../../src/components/PurchaseOrder/Summary/FieldWorkflowStatus';
+
+const RECEIVING_LIST_COUNT = 10;
+
+describe('Receiving', () => {
+  setupApplication();
+
+  let order = null;
+  const orderDetailsPage = new OrderDetailsPage();
+  const page = new ReceivingHistoryPage();
+
+  beforeEach(async function () {
+    order = await this.server.create('order', {
+      workflow_status: WORKFLOW_STATUS.open,
+    });
+
+    this.server.createList('piece', RECEIVING_LIST_COUNT);
+
+    await this.visit(`/orders/view/${order.id}/receiving-history`);
+  });
+
+  it('displays Receiving History screen', () => {
+    expect(page.$root).to.exist;
+  });
+
+  it('displays Close button', () => {
+    expect(page.closeButton.isButton).to.be.true;
+  });
+
+  describe('go back from Receiving History page to Order Details pane', () => {
+    beforeEach(async function () {
+      await page.closeButton.click();
+    });
+
+    it('go to Order Details pane', () => {
+      expect(orderDetailsPage.$root).to.exist;
+    });
+  });
+});

--- a/translations/ui-orders/en.json
+++ b/translations/ui-orders/en.json
@@ -484,6 +484,8 @@
   "renewals.renewalDate": "Renewal Date",
   "renewals.renewalInterval": "Renewal Interval",
   "renewals.reviewPeriod": "Review Period",
+  "receiving.links.items": "Receiving items",
+  "receiving.links.history": "Receiving history",
   "receiving.paneTitle": "Receive Items",
   "receiving.receiveBtn": "Receive",
   "receiving.receiveAllBtn": "Receive All",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIREC-14
Button Group to help User navigate between Receiving Items and History

## Approach
Several React Router routes were created to support navigation.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
