### PR TITLE
UIREC-21 fix warning and Remove button disabling

### DIFF
--- a/src/components/Receiving/ReceivingHistory.js
+++ b/src/components/Receiving/ReceivingHistory.js
@@ -159,7 +159,7 @@ class ReceivingHistory extends Component {
     const { mutator, location, resources } = this.props;
     const contentData = this.getData(resources);
     const orderNumber = get(resources, ['order', 'records', 0, 'po_number']);
-    const isRemoveButtonDisabled = Object.values(checkedPiecesMap).length === 0;
+    const isRemoveButtonDisabled = Object.values(checkedPiecesMap).filter(Boolean).length === 0;
     const resultsFormatter = {
       'isChecked': (piece) => (
         <Checkbox
@@ -236,14 +236,16 @@ class ReceivingHistory extends Component {
             />
           </Pane>
         </Paneset>
-        <ConfirmationModal
-          confirmLabel={<FormattedMessage id="ui-orders.receivingHistory.confirmation.confirm" />}
-          heading={<FormattedMessage id="ui-orders.receivingHistory.confirmation.heading" />}
-          message={<FormattedMessage id="ui-orders.receivingHistory.confirmation.message" />}
-          onCancel={this.hideConfirm}
-          onConfirm={this.handleSubmit}
-          open={confirming}
-        />
+        {confirming && (
+          <ConfirmationModal
+            confirmLabel={<FormattedMessage id="ui-orders.receivingHistory.confirmation.confirm" />}
+            heading={<FormattedMessage id="ui-orders.receivingHistory.confirmation.heading" />}
+            message={<FormattedMessage id="ui-orders.receivingHistory.confirmation.message" />}
+            onCancel={this.hideConfirm}
+            onConfirm={this.handleSubmit}
+            open
+          />
+        )}
         <Callout ref={this.callout} />
       </div>
     );


### PR DESCRIPTION
## Purpose
* Render Confirmation modal only after Receive button is clicked.
* Remove button stays enabled if line is unchecked.
https://issues.folio.org/browse/UIREC-21

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
