### PR TITLE
UIOR-144 disable Add line button for non-pending orders

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,7 @@
         ]
       }
     ],
-    "react/jsx-one-expression-per-line": false,
+    "react/jsx-one-expression-per-line": 0,
     "comma-dangle": [
       "error",
       {

--- a/src/components/PurchaseOrder/PO.js
+++ b/src/components/PurchaseOrder/PO.js
@@ -192,9 +192,10 @@ class PO extends Component {
     }
   }
 
-  addPOLineButton = (
+  addPOLineButton = (isAbleToAddLines) => (
     <Button
       data-test-add-line-button
+      disabled={!isAbleToAddLines}
       onClick={this.onAddPOLine}
     >
       <FormattedMessage id="ui-orders.button.addLine" />
@@ -249,6 +250,7 @@ class PO extends Component {
     const workflowStatus = get(order, 'workflowStatus');
     const isCloseOrderButtonVisible = workflowStatus === WORKFLOW_STATUS.open;
     const isReceiveButtonVisible = isReceiveAvailableForOrder(order);
+    const isAbleToAddLines = workflowStatus === WORKFLOW_STATUS.pending;
 
     const lastMenu = (
       <PaneMenu>
@@ -368,7 +370,7 @@ class PO extends Component {
             <SummaryView order={order} {...this.props} />
           </Accordion>
           <Accordion
-            displayWhenOpen={this.addPOLineButton}
+            displayWhenOpen={this.addPOLineButton(isAbleToAddLines)}
             id="POListing"
             label={<FormattedMessage id="ui-orders.paneBlock.POLines" />}
           >

--- a/test/bigtest/.eslintrc
+++ b/test/bigtest/.eslintrc
@@ -1,8 +1,8 @@
-module.exports = {
-  rules: {
+{
+  "rules": {
     "filenames/match-exported": "off",
     "func-names": "off",
     "no-unused-expressions": "off",
     "one-var": "off"
   }
-};
+}

--- a/test/bigtest/interactors/order-details-page.js
+++ b/test/bigtest/interactors/order-details-page.js
@@ -1,8 +1,9 @@
 import {
-  interactor,
   clickable,
-  text,
+  interactor,
   is,
+  property,
+  text,
 } from '@bigtest/interactor';
 
 @interactor class EditOrderButton {
@@ -15,10 +16,17 @@ import {
   isButton = is('button');
 }
 
+@interactor class AddLineButton {
+  static defaultScope = '[data-test-add-line-button]';
+  isButton = is('button');
+  click = clickable();
+  isDisabled = property('disabled');
+}
+
 export default interactor(class OrderDetailsPage {
   static defaultScope = '[data-test-order-details]';
   title = text('[class*=paneTitleLabel---]');
   editOrderButton = new EditOrderButton();
-  addLineButton = clickable('[data-test-add-line-button]');
+  addLineButton = new AddLineButton();
   receivingButton = new ReceiveButton();
 });

--- a/test/bigtest/tests/details-order-test.js
+++ b/test/bigtest/tests/details-order-test.js
@@ -5,6 +5,7 @@ import {
 } from '@bigtest/mocha';
 import { expect } from 'chai';
 
+import { WORKFLOW_STATUS } from '../../../src/components/PurchaseOrder/Summary/FieldWorkflowStatus';
 import setupApplication from '../helpers/setup-application';
 import OrderDetailsPage from '../interactors/order-details-page';
 import OrderEditPage from '../interactors/order-edit-page';
@@ -20,13 +21,18 @@ describe('OrderDetailsPage', () => {
   let order = null;
 
   beforeEach(function () {
-    order = this.server.create('order');
+    order = this.server.create('order', { workflowStatus: WORKFLOW_STATUS.pending });
 
     this.visit(`/orders/view/${order.id}`);
   });
 
   it('displays the order number in the pane header', () => {
     expect(orderDetailsPage.title).to.include(order.poNumber);
+  });
+
+  it('displays the Add Line button enabled', () => {
+    expect(orderDetailsPage.addLineButton.isButton).to.equal(true);
+    expect(orderDetailsPage.addLineButton.isDisabled).to.equal(false);
   });
 
   describe('clicking on edit', () => {
@@ -39,9 +45,37 @@ describe('OrderDetailsPage', () => {
     });
   });
 
+  describe('Add Line button should be disabled for Closed orders', () => {
+    let closedOrder = null;
+
+    beforeEach(function () {
+      closedOrder = this.server.create('order', { workflowStatus: WORKFLOW_STATUS.closed });
+
+      this.visit(`/orders/view/${closedOrder.id}`);
+    });
+
+    it('Add Line button is disabled', () => {
+      expect(orderDetailsPage.addLineButton.isDisabled).to.equal(true);
+    });
+  });
+
+  describe('Add Line button should be disabled for Open orders', () => {
+    let openOrder = null;
+
+    beforeEach(function () {
+      openOrder = this.server.create('order', { workflowStatus: WORKFLOW_STATUS.open });
+
+      this.visit(`/orders/view/${openOrder.id}`);
+    });
+
+    it('Add Line button is disabled', () => {
+      expect(orderDetailsPage.addLineButton.isDisabled).to.equal(true);
+    });
+  });
+
   describe('clicking on add Line', () => {
     beforeEach(async () => {
-      await orderDetailsPage.addLineButton();
+      await orderDetailsPage.addLineButton.click();
     });
 
     it('should redirect to add line page', () => {


### PR DESCRIPTION
## Purpose
To improve UX instead of error messages on calling back-en for Add PO Line it's better to disable button leading to Add PO Line form.
https://issues.folio.org/browse/UIOR-144

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
