### PR TITLE
UIOR-154 fix checking lines to receive

### DIFF
--- a/src/components/Receiving/ItemDetails.js
+++ b/src/components/Receiving/ItemDetails.js
@@ -166,6 +166,7 @@ class ItemDetails extends Component {
 
     return (
       <Modal
+        id="data-test-piece-details-modal"
         label={
           (currentLine >= poLineIdsList.length)
             ? <FormattedMessage id="ui-orders.receiving.reviewDetails" />

--- a/src/components/Receiving/ReceivingList.js
+++ b/src/components/Receiving/ReceivingList.js
@@ -123,26 +123,25 @@ class ReceivingList extends Component {
     </PaneMenu>
   );
 
-  isLineChecked = (line) => (
-    this.state.itemDetails[line.poLineId]
-      ? Boolean(this.state.itemDetails[line.poLineId].length)
-      : false
-  )
-
   toggleLine = (line, receivingList) => {
-    this.setState(({ itemDetails }) => ({
-      isAllChecked: false,
-      itemDetails: {
-        ...itemDetails,
-        ...{
-          [line.poLineId]: this.isLineChecked(line)
-            ? []
-            : receivingList.filter(el => (
-              el.poLineId === line.poLineId && el.receivingStatus === PIECE_STATUS_EXPECTED
-            )),
-        },
-      },
-    }));
+    this.setState(state => {
+      const lineId = line.poLineId;
+      const isLineCheckedAlready = lineId in state.itemDetails;
+      const itemDetails = { ...state.itemDetails };
+
+      if (isLineCheckedAlready) {
+        delete itemDetails[lineId];
+      } else {
+        itemDetails[lineId] = receivingList.filter(el => (
+          el.poLineId === lineId && el.receivingStatus === PIECE_STATUS_EXPECTED
+        ));
+      }
+
+      return {
+        isAllChecked: false,
+        itemDetails,
+      };
+    });
   }
 
   toggleAll = (receivingList) => {
@@ -182,6 +181,7 @@ class ReceivingList extends Component {
 
   render() {
     const { resources, mutator, location } = this.props;
+    const { itemDetails } = this.state;
     const receivingList = get(resources, ['receivingHistory', 'records'], []);
     const uniqReceivingList = getLinesRows(receivingList);
     const orderNumber = get(resources, ['receivingHistory', 'records', 0, 'poLineNumber'], '-').split('-')[0];
@@ -189,7 +189,7 @@ class ReceivingList extends Component {
       'isChecked': line => (
         <Checkbox
           type="checkbox"
-          checked={this.isLineChecked(line)}
+          checked={itemDetails[line.poLineId]}
           onChange={() => this.toggleLine(line, receivingList)}
         />
       ),
@@ -200,7 +200,7 @@ class ReceivingList extends Component {
       'receivingNote': line => get(line, 'receivingNote', ''),
       'receiptStatus': () => <FormattedMessage id="ui-orders.receiving.lineStatus.expected" />,
     };
-    const isReceiveButtonDisabled = !some(Object.values(this.state.itemDetails), (line => line.length > 0));
+    const isReceiveButtonDisabled = !some(Object.values(itemDetails), (line => line.length > 0));
 
     return (
       <div data-test-receiving>
@@ -250,6 +250,7 @@ class ReceivingList extends Component {
                 receiptStatus: <FormattedMessage id="ui-orders.receiving.status" />,
               }}
               columnWidths={{ isChecked: '35px' }}
+              onRowClick={(_, line) => this.toggleLine(line, receivingList)}
             />
             {this.state.isItemDetailsModalOpened && (
               <ItemDetails

--- a/test/bigtest/interactors/piece-details-modal.js
+++ b/test/bigtest/interactors/piece-details-modal.js
@@ -1,0 +1,9 @@
+import {
+  collection,
+  interactor,
+} from '@bigtest/interactor';
+
+export default interactor(class PieceDetailsModal {
+  static defaultScope = '#data-test-piece-details-modal';
+  piecesInLine = collection('[class*=mclRow---]');
+});

--- a/test/bigtest/tests/piece-details-test.js
+++ b/test/bigtest/tests/piece-details-test.js
@@ -1,0 +1,71 @@
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import PieceDetailsModal from '../interactors/piece-details-modal';
+import ReceivingPage from '../interactors/receiving-page';
+import { WORKFLOW_STATUS } from '../../../src/components/PurchaseOrder/Summary/FieldWorkflowStatus';
+import { PHYSICAL } from '../../../src/components/POLine/const';
+import { PIECE_STATUS_EXPECTED } from '../../../src/components/Receiving/const';
+import {
+  ORDERS_API,
+} from '../../../src/components/Utils/api';
+
+const RECEIVING_LIST_COUNT = 10;
+// const TEST_BARCODE = 111;
+
+describe('Piece Details Modal', () => {
+  setupApplication();
+
+  let order = null;
+  // let items = null;
+  let line = null;
+  const modal = new PieceDetailsModal();
+  const receivingPage = new ReceivingPage();
+
+  beforeEach(async function () {
+    order = this.server.create('order', {
+      workflowStatus: WORKFLOW_STATUS.open,
+    });
+    line = this.server.create('line', {
+      order,
+      orderFormat: PHYSICAL,
+      cost: {
+        quantityPhysical: 2,
+      },
+    });
+    this.server.get(`${ORDERS_API}/${order.id}`, {
+      ...order.attrs,
+      compositePoLines: [line.attrs],
+    });
+    // items = this.server.createList('item', RECEIVING_LIST_COUNT);
+
+    this.server.createList('piece', RECEIVING_LIST_COUNT, {
+      receivingStatus: PIECE_STATUS_EXPECTED,
+      poLineId: line.id,
+      // itemId: items[0].id,
+    });
+
+    await this.visit(`/orders/view/${order.id}/receiving`);
+    await receivingPage.receivingList(0).click();
+    await receivingPage.receivePiecesButton.click();
+  });
+
+  it('displays Piece Details modal', () => {
+    expect(modal.$root).to.exist;
+  });
+
+  it('displays pieces', () => {
+    expect(modal.piecesInLine().length).to.be.equal(RECEIVING_LIST_COUNT);
+  });
+
+  // describe('barcode could be changed', () => {
+  //   beforeEach(async () => {
+  //     await modal.barcodeInput.fill(TEST_BARCODE);
+  //   });
+
+  //   it('barcode value is changed to "test"', () => {
+  //     expect(modal.barcodeInput.value).to.be.equal(TEST_BARCODE);
+  //   });
+  // });
+});


### PR DESCRIPTION
## Purpose
It's a fix to provide selected lines correctly into Piece Details modal
https://issues.folio.org/browse/UIOR-154

## Approach
in setState() we should never mutate objects, only set a new one, so React can see that change is happened.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
