### PR TITLE
UIOR-128 E-resource and Physical resource accordions don't display

### DIFF
--- a/src/components/LayerCollection/LayerPOLine.js
+++ b/src/components/LayerCollection/LayerPOLine.js
@@ -62,6 +62,7 @@ class LayerPOLine extends Component {
   })
 
   static propTypes = {
+    connectedSource: PropTypes.object.isRequired,
     location: ReactRouterPropTypes.location.isRequired,
     match: ReactRouterPropTypes.match,
     parentMutator: PropTypes.shape({
@@ -233,6 +234,7 @@ class LayerPOLine extends Component {
 
   render() {
     const {
+      connectedSource,
       location,
       onCancel,
       parentMutator,
@@ -251,6 +253,7 @@ class LayerPOLine extends Component {
           contentLabel="Create PO Line Dialog"
         >
           <this.connectedPOLineForm
+            connectedSource={connectedSource}
             initialValues={this.getCreatePOLIneInitialValues(order)}
             onCancel={onCancel}
             onSubmit={this.submitPOLine}
@@ -275,6 +278,7 @@ class LayerPOLine extends Component {
           contentLabel="Edit PO Line Dialog"
         >
           <this.connectedPOLineForm
+            connectedSource={connectedSource}
             deletePOLine={this.deletePOLine}
             initialValues={this.getLine()}
             onCancel={onCancel}

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -323,5 +323,4 @@ class POLineForm extends Component {
 export default stripesForm({
   form: 'POLineForm',
   navigationCheck: true,
-  enableReinitialize: true,
 })(POLineForm);


### PR DESCRIPTION
## Purpose
This is the fix of regression.
There is a bug when form component of PO Line is not refreshed on form field change. It confuses a user, since on any refresh accordions could be re-arranged.
https://issues.folio.org/browse/UIOR-128

## Learning
Apparently we have to pass down `connectedSource` property to get all stored form values in sync

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
