### PR TITLE
UIOR-226 Access Receiving/Checkin history for closed orders

### DIFF
--- a/src/components/POLine/POLine.js
+++ b/src/components/POLine/POLine.js
@@ -71,7 +71,7 @@ class POLine extends Component {
     const funds = get(this.props.parentResources, 'fund.records', []);
     const poURL = this.props.poURL;
     const receivingURL = `${match.url}/receiving`;
-    const checkinURL = `${match.url}/check-in/items`;
+    const checkinURL = `${match.url}/check-in`;
 
     return (
       <POLineView

--- a/src/components/POLine/POLineView.js
+++ b/src/components/POLine/POLineView.js
@@ -23,6 +23,7 @@ import {
   isCheckInAvailableForLine,
   isReceiveAvailableForLine,
 } from '../PurchaseOrder/util';
+import { WORKFLOW_STATUS } from '../PurchaseOrder/Summary/FieldWorkflowStatus';
 
 import LocationView from './Location/LocationView';
 import { POLineDetails } from './POLineDetails';
@@ -231,6 +232,9 @@ class POLineView extends Component {
     const showOther = orderFormat === OTHER;
     const isReceiveButtonVisible = isReceiveAvailableForLine(line, order);
     const isCheckInButtonVisible = isCheckInAvailableForLine(line, order);
+    const isWorkflowStatusOpen = order.workflowStatus === WORKFLOW_STATUS.open;
+    const checkInLocation = isWorkflowStatusOpen ? `${checkinURL}/items` : `${checkinURL}/history`;
+    const receivingLocation = isWorkflowStatusOpen ? receivingURL : `${receivingURL}-history`;
 
     return (
       <Pane
@@ -250,7 +254,7 @@ class POLineView extends Component {
                 <Button
                   buttonStyle="primary"
                   data-test-line-receive-button
-                  to={receivingURL}
+                  to={receivingLocation}
                 >
                   <FormattedMessage id="ui-orders.paneBlock.receiveBtn" />
                 </Button>
@@ -261,7 +265,7 @@ class POLineView extends Component {
                 <Button
                   buttonStyle="primary"
                   data-test-line-check-in-button
-                  to={checkinURL}
+                  to={checkInLocation}
                 >
                   <FormattedMessage id="ui-orders.paneBlock.checkInBtn" />
                 </Button>

--- a/src/components/PurchaseOrder/PO.js
+++ b/src/components/PurchaseOrder/PO.js
@@ -281,9 +281,10 @@ class PO extends Component {
 
   goToReceiving = () => {
     const { match: { params: { id } }, parentMutator: { query } } = this.props;
+    const order = this.getOrder();
 
     query.replace({
-      _path: `/orders/view/${id}/receiving`,
+      _path: `/orders/view/${id}/${order.workflowStatus === WORKFLOW_STATUS.open ? 'receiving' : 'receiving-history'}`,
     });
   };
 

--- a/src/components/PurchaseOrder/util.js
+++ b/src/components/PurchaseOrder/util.js
@@ -14,27 +14,27 @@ const isLineAbleToBeReceived = (line = { cost: {} }) => {
   return isNotCheckin && hasQuantity && hasCorrectReceiptStatus;
 };
 
-const isWorkflowStatusOpen = (order) => {
+const isWorkflowStatusNotPending = (order) => {
   const { workflowStatus } = order;
 
-  return workflowStatus === WORKFLOW_STATUS.open;
+  return workflowStatus !== WORKFLOW_STATUS.pending;
 };
 
 export const isReceiveAvailableForLine = (line = {}, order = {}) => {
   const hasLineItemsToReceive = isLineAbleToBeReceived(line);
 
-  return hasLineItemsToReceive && isWorkflowStatusOpen(order);
+  return hasLineItemsToReceive && isWorkflowStatusNotPending(order);
 };
 
 export const isCheckInAvailableForLine = (line = {}, order = {}) => {
-  return line.checkinItems && isWorkflowStatusOpen(order);
+  return line.checkinItems && isWorkflowStatusNotPending(order);
 };
 
 export const isReceiveAvailableForOrder = (order = {}) => {
   const { compositePoLines = [] } = order;
   const hasLineItemsToReceive = some(compositePoLines, isLineAbleToBeReceived);
 
-  return hasLineItemsToReceive && isWorkflowStatusOpen(order);
+  return hasLineItemsToReceive && isWorkflowStatusNotPending(order);
 };
 
 const EMPTY_OPTION = {

--- a/test/bigtest/tests/receiving-list-test.js
+++ b/test/bigtest/tests/receiving-list-test.js
@@ -52,6 +52,41 @@ describe('Receiving', function () {
     expect(orderDetailsPage.receivingButton.isButton).to.be.true;
   });
 
+  describe('go to receiving history from closed PO', () => {
+    beforeEach(function () {
+      order = this.server.create('order', {
+        workflowStatus: WORKFLOW_STATUS.closed,
+      });
+      line = this.server.create('line', {
+        order,
+        orderFormat: PHYSICAL,
+        cost: {
+          quantityPhysical: 2,
+        },
+      });
+      this.server.get(`${ORDERS_API}/${order.id}`, {
+        ...order.attrs,
+        compositePoLines: [line.attrs],
+      });
+
+      this.visit(`/orders/view/${order.id}`);
+    });
+
+    it('displays the Receive button', () => {
+      expect(orderDetailsPage.receivingButton.isButton).to.be.true;
+    });
+
+    describe('go to receiving history', () => {
+      beforeEach(async function () {
+        await orderDetailsPage.receivingButton.click();
+      });
+
+      it('displays Receiving history screen', () => {
+        expect(receivingHistoryPage.$root).to.exist;
+      });
+    });
+  });
+
   describe('go to receiving list', () => {
     beforeEach(async function () {
       await orderDetailsPage.receivingButton.click();


### PR DESCRIPTION
## Purpose
User should be able to view receiving history for Closed order
https://issues.folio.org/browse/UIOR-226
## Approach
Receiving or checkIn button is visible if order open or close.
Check `workflowStatus` to redirect the user to items or history.
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
