### PR TITLE
UIOR-379 Template fix: Account number field

### DIFF
--- a/src/common/POLFields/VendorFields/FieldVendorAccountNumber.js
+++ b/src/common/POLFields/VendorFields/FieldVendorAccountNumber.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { Field } from 'redux-form';
 
+import { TextField } from '@folio/stripes/components';
 import {
   FieldSelect,
   fieldSelectOptionsShape,
@@ -9,13 +11,24 @@ import {
 
 const FieldVendorAccountNumber = ({ accounts, disabled }) => {
   return (
-    <FieldSelect
-      dataOptions={accounts}
-      fullWidth
-      label={<FormattedMessage id="ui-orders.vendor.accountNumber" />}
-      name="vendorDetail.vendorAccount"
-      disabled={disabled}
-    />
+    accounts.length
+      ? (
+        <FieldSelect
+          dataOptions={accounts}
+          fullWidth
+          label={<FormattedMessage id="ui-orders.vendor.accountNumber" />}
+          name="vendorDetail.vendorAccount"
+          disabled={disabled}
+        />
+      )
+      : (
+        <Field
+          component={TextField}
+          fullWidth
+          label={<FormattedMessage id="ui-orders.vendor.accountNumber" />}
+          name="vendorDetail.vendorAccount"
+        />
+      )
   );
 };
 

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
@@ -72,6 +72,7 @@ class OrderTemplatesEditor extends Component {
     vendors: PropTypes.arrayOf(PropTypes.object),
     materialTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
     title: PropTypes.node,
+    accounts: PropTypes.arrayOf(PropTypes.object),
   };
 
   state = {
@@ -151,6 +152,7 @@ class OrderTemplatesEditor extends Component {
       dispatch,
       change,
       title,
+      accounts,
     } = this.props;
     const { sections } = this.state;
     const orderFormat = formValues.orderFormat;
@@ -299,7 +301,7 @@ class OrderTemplatesEditor extends Component {
                     label={ORDER_TEMPLATES_ACCORDION_TITLES[ORDER_TEMPLATES_ACCORDION.POL_VENDOR]}
                     id={ORDER_TEMPLATES_ACCORDION.POL_VENDOR}
                   >
-                    <POLineVendorForm />
+                    <POLineVendorForm accounts={accounts} />
                   </Accordion>
 
                   <Accordion

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.js
@@ -83,7 +83,8 @@ class OrderTemplatesEditorContainer extends Component {
     const identifierTypes = getIdentifierTypesForSelect(resources);
     const contributorNameTypes = getContributorNameTypesForSelect(resources);
     const createInventorySetting = getCreateInventorySetting(get(resources, ['createInventory', 'records'], []));
-    const vendors = getVendorOptions(get(resources, 'vendors.records', []));
+    const vendors = get(resources, 'vendors.records', []);
+    const vendorOptions = getVendorOptions(vendors);
     const prefixesSetting = getSettingsList(get(resources, 'prefixesSetting.records', {}));
     const suffixesSetting = getSettingsList(get(resources, 'suffixesSetting.records', {}));
     const addresses = getAddressOptions(getAddresses(get(resources, 'addresses.records', [])));
@@ -92,6 +93,11 @@ class OrderTemplatesEditorContainer extends Component {
       ? get(resources, ['orderTemplate', 'records', 0], INITIAL_VALUES)
       : INITIAL_VALUES;
     const title = get(orderTemplate, ['templateName']) || <FormattedMessage id="ui-orders.settings.orderTemplates.editor.titleCreate" />;
+    const vendor = vendors.find(v => v.id === get(formValues, 'vendor'));
+    const accounts = get(vendor, 'accounts', []).map(({ accountNo }) => ({
+      label: accountNo,
+      value: accountNo,
+    }));
 
     return (
       <OrderTemplatesEditor
@@ -106,10 +112,11 @@ class OrderTemplatesEditorContainer extends Component {
         prefixesSetting={prefixesSetting.selectedItems}
         suffixesSetting={suffixesSetting.selectedItems}
         addresses={addresses}
-        vendors={vendors}
+        vendors={vendorOptions}
         materialTypes={materialTypes}
         formValues={formValues}
         contributorNameTypes={contributorNameTypes}
+        accounts={accounts}
       />
     );
   }

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/POLineVendorForm/POLineVendorForm.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/POLineVendorForm/POLineVendorForm.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   Row,
@@ -13,7 +14,7 @@ import {
   FieldVendorNote,
 } from '../../../../common/POLFields';
 
-const POLineVendorForm = () => {
+const POLineVendorForm = ({ accounts }) => {
   return (
     <Row>
       <Col
@@ -34,7 +35,7 @@ const POLineVendorForm = () => {
         xs={3}
         data-col-order-template-vendor-account
       >
-        <FieldVendorAccountNumber />
+        <FieldVendorAccountNumber accounts={accounts} />
       </Col>
 
       <Col
@@ -52,6 +53,14 @@ const POLineVendorForm = () => {
       </Col>
     </Row>
   );
+};
+
+POLineVendorForm.propTypes = {
+  accounts: PropTypes.arrayOf(PropTypes.object),
+};
+
+POLineVendorForm.defaultProps = {
+  accounts: [],
 };
 
 export default POLineVendorForm;


### PR DESCRIPTION
## Purpose
- If a vendor is assigned in the template, and accounts are in the vendor record, the Account field should display the accounts associated with that vendor, but only allow 1 to be selected
- If a vendor is assigned in the template, and account numbers are NOT available in the vendor record, the Account field should be a free-text field
- If a vendor is NOT assigned in the template, the Account field should be a free-text field
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
