### PR TITLE
Remove explicit fake-xml-http-request in advance for the stripes-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,9 +274,6 @@
     "react-dom": "*",
     "react-router-dom": "^5.1.2"
   },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
-  },
   "optionalDependencies": {
     "@folio/plugin-create-item": "^1.3.1",
     "@folio/plugin-find-instance": "^1.5.0",


### PR DESCRIPTION
Having multiple versions of the fake-xml-http-request can prevent patching.