### PR TITLE
UIOR-552 fix to loose and set up again link to instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 * [UIOR-555](https://issues.folio.org/browse/UIOR-555) Refine styling of Title field at PO Line form
+* [UIOR-554](https://issues.folio.org/browse/UIOR-554) Click on instance doesn't select it and plugin-find-instance doesn't close
 * [UIOR-552](https://issues.folio.org/browse/UIOR-552) Can not remove product ID without disconnecting instance
 
 ## [2.0.3](https://github.com/folio-org/ui-orders/tree/v2.0.3) (2020-04-09)

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -1,8 +1,10 @@
+/* eslint-disable react/no-unused-state */
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import {
   Field,
+  getFormValues,
 } from 'redux-form';
 import { Link } from 'react-router-dom';
 
@@ -35,7 +37,7 @@ import ContributorForm from './ContributorForm';
 import ProductIdDetailsForm from './ProductIdDetailsForm';
 import InstancePlugin from './InstancePlugin';
 import {
-  checkInstanceIdField,
+  shouldSetInstanceId,
   getInventoryData,
 } from './util';
 import { isWorkflowStatusIsPending } from '../../PurchaseOrder/util';
@@ -51,8 +53,10 @@ class ItemForm extends Component {
     contributorNameTypes: PropTypes.arrayOf(PropTypes.object),
     initialValues: PropTypes.object,
     order: PropTypes.object.isRequired,
+    formName: PropTypes.string.isRequired,
     formValues: PropTypes.object.isRequired,
     required: PropTypes.bool,
+    stripes: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -63,14 +67,7 @@ class ItemForm extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      title: '',
-      publisher: '',
-      publicationDate: '',
-      edition: '',
-      contributors: [],
-      productIds: [],
-    };
+    this.state = getInventoryData(props.initialValues);
   }
 
   onAddInstance = (instance) => {
@@ -145,12 +142,14 @@ class ItemForm extends Component {
   };
 
   onChangeField = (value, fieldName) => {
-    const { formValues, dispatch, change, initialValues } = this.props;
-    const inventoryData = getInventoryData(this.state, initialValues);
+    const { formName, dispatch, change, stripes: { store } } = this.props;
+    const inventoryData = this.state;
 
     dispatch(change(fieldName, value));
 
-    if (checkInstanceIdField(formValues, inventoryData)) {
+    const formValues = getFormValues(formName)(store.getState());
+
+    if (shouldSetInstanceId(formValues, inventoryData)) {
       dispatch(change('instanceId', inventoryData.instanceId));
     } else dispatch(change('instanceId', null));
   };
@@ -179,7 +178,7 @@ class ItemForm extends Component {
   };
 
   getTitleLabel = () => {
-    const { required, formValues, initialValues } = this.props;
+    const { required, formValues } = this.props;
     const instanceId = get(formValues, 'instanceId');
     const isPackage = get(formValues, 'isPackage');
     const title = (
@@ -217,7 +216,7 @@ class ItemForm extends Component {
       </>
     );
 
-    if (!initialValues.instanceId && !this.state.instanceId) {
+    if (!this.state.instanceId) {
       return title;
     }
 

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -7,7 +7,6 @@ import {
   getFormValues,
 } from 'redux-form';
 import { Link } from 'react-router-dom';
-
 import { get } from 'lodash';
 
 import {
@@ -25,6 +24,7 @@ import {
   selectOptionsShape,
   validateRequired,
 } from '@folio/stripes-acq-components';
+import { stripesShape } from '@folio/stripes/core';
 
 import {
   validateYear,
@@ -56,7 +56,7 @@ class ItemForm extends Component {
     formName: PropTypes.string.isRequired,
     formValues: PropTypes.object.isRequired,
     required: PropTypes.bool,
-    stripes: PropTypes.object.isRequired,
+    stripes: stripesShape.isRequired,
   };
 
   static defaultProps = {

--- a/src/components/POLine/Item/ProductIdDetailsForm.js
+++ b/src/components/POLine/Item/ProductIdDetailsForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -20,12 +20,18 @@ import {
 const DEFAULT_ID_TYPES = [];
 
 function ProductIdDetailsForm({ disabled, onChangeField, identifierTypes, required }) {
+  const removeField = useCallback((fields, index) => {
+    fields.remove(index);
+    onChangeField();
+  }, [onChangeField]);
+
   const renderSubForm = (elem) => {
     return (
       <Row>
         <Col xs>
           <Field
             component={TextField}
+            data-test-productId
             fullWidth
             label={<FormattedMessage id="ui-orders.itemDetails.productId" />}
             name={`${elem}.productId`}
@@ -69,6 +75,7 @@ function ProductIdDetailsForm({ disabled, onChangeField, identifierTypes, requir
       id="productIds"
       legend={<FormattedMessage id="ui-orders.itemDetails.productIds" />}
       name="details.productIds"
+      onRemove={removeField}
       props={{
         canAdd: !disabled,
         canRemove: !disabled,

--- a/src/components/POLine/Item/ProductIdDetailsForm.js
+++ b/src/components/POLine/Item/ProductIdDetailsForm.js
@@ -31,7 +31,6 @@ function ProductIdDetailsForm({ disabled, onChangeField, identifierTypes, requir
         <Col xs>
           <Field
             component={TextField}
-            data-test-productId
             fullWidth
             label={<FormattedMessage id="ui-orders.itemDetails.productId" />}
             name={`${elem}.productId`}

--- a/src/components/POLine/Item/util.js
+++ b/src/components/POLine/Item/util.js
@@ -37,7 +37,7 @@ export const shouldSetInstanceId = (formValues, inventoryData) => {
     inventoryData.instanceId
     && (inventoryData.title === get(formValues, 'titleOrPackage', ''))
     && (inventoryData.publisher === get(formValues, 'publisher', ''))
-    && (inventoryData.publicationDate === get(formValues, 'publicationDate', ''))
+    && (inventoryData.publicationDate === (formValues?.publicationDate || '')) // publicationDate might be null in form values
     && (inventoryData.edition === get(formValues, 'edition', ''))
     && isEqualContributors
     && isEqualProductIds

--- a/src/components/POLine/Item/util.js
+++ b/src/components/POLine/Item/util.js
@@ -4,25 +4,21 @@ import {
   isEqual,
 } from 'lodash';
 
-export const getInventoryData = (state, initialValues) => {
-  const { title, publisher, publicationDate, edition, contributors, productIds } = state;
-
+// transform form's initialValues to the state of data from inventory
+export const getInventoryData = (initialValues) => {
   return {
-    instanceId: get(state, 'instanceId', null) || get(initialValues, 'instanceId', null),
-    title: title || get(initialValues, 'titleOrPackage', ''),
-    publisher: publisher || get(initialValues, 'publisher', ''),
-    publicationDate: publicationDate || get(initialValues, 'publicationDate', ''),
-    edition: edition || get(initialValues, 'edition', ''),
-    contributors: contributors.length
-      ? contributors
-      : get(initialValues, 'contributors', []),
-    productIds: productIds.length
-      ? productIds
-      : get(initialValues, 'details.productIds', []),
+    instanceId: get(initialValues, 'instanceId', null),
+    title: get(initialValues, 'titleOrPackage', ''),
+    publisher: get(initialValues, 'publisher', ''),
+    publicationDate: get(initialValues, 'publicationDate', ''),
+    edition: get(initialValues, 'edition', ''),
+    contributors: get(initialValues, 'contributors', []),
+    productIds: get(initialValues, 'details.productIds', []),
   };
 };
 
-export const checkInstanceIdField = (formValues, inventoryData) => {
+// It compares actual form data (formValues) to contain data came from inventory or initial get request (inventoryData)
+export const shouldSetInstanceId = (formValues, inventoryData) => {
   const isEqualContributors = inventoryData.contributors.every(el => {
     const contributor = find(get(formValues, 'contributors', []), { 'contributor': el.contributor });
 
@@ -45,6 +41,6 @@ export const checkInstanceIdField = (formValues, inventoryData) => {
     && (inventoryData.edition === get(formValues, 'edition', ''))
     && isEqualContributors
     && isEqualProductIds
-    && get(formValues, 'isPackage')
+    && !formValues?.isPackage
   );
 };

--- a/src/components/POLine/Item/util.test.js
+++ b/src/components/POLine/Item/util.test.js
@@ -1,0 +1,117 @@
+import '@folio/stripes-acq-components/test/jest/__mock__';
+
+import {
+  getInventoryData,
+  shouldSetInstanceId,
+} from './util';
+
+const formValues = {
+  contributors: [{
+    contributor: 'c1',
+    contributorNameTypeId: 'ct1',
+  }],
+  details: {
+    productIds: [
+      {
+        productId: '410 254-2',
+        productIdType: 'b5d8cdc4-9441-487c-90cf-0c7ec97728eb',
+      },
+      {
+        productId: 'London',
+        productIdType: 'b5d8cdc4-9441-487c-90cf-0c7ec97728eb',
+      },
+    ],
+  },
+  isPackage: false,
+  titleOrPackage: 'some title',
+};
+const inventoryData = getInventoryData({ ...formValues, instanceId: 'someId' });
+
+describe('shouldSetInstanceId', () => {
+  it('should return false if checkbox isPackage is checked', () => {
+    const isPackageFormValues = {
+      ...formValues,
+      isPackage: true,
+    };
+
+    expect(shouldSetInstanceId(isPackageFormValues, inventoryData)).toBeFalsy();
+  });
+
+  it('should return true if form data contains inventory data', () => {
+    expect(shouldSetInstanceId({ ...formValues, instanceId: 'someId' }, inventoryData)).toBeTruthy();
+  });
+
+  it('should return true if form data contains inventory data and it lost instanceId link', () => {
+    expect(shouldSetInstanceId(formValues, inventoryData)).toBeTruthy();
+  });
+
+  it('should return false if title was changed', () => {
+    expect(shouldSetInstanceId({ ...formValues, titleOrPackage: 'new' }, inventoryData)).toBeFalsy();
+  });
+
+  it('should return false if publisher was changed', () => {
+    expect(shouldSetInstanceId({ ...formValues, publisher: 'new' }, inventoryData)).toBeFalsy();
+  });
+
+  it('should return false if publicationDate was changed', () => {
+    expect(shouldSetInstanceId({ ...formValues, publicationDate: 'new' }, inventoryData)).toBeFalsy();
+  });
+
+  it('should return false if edition was changed', () => {
+    expect(shouldSetInstanceId({ ...formValues, edition: 'new' }, inventoryData)).toBeFalsy();
+  });
+
+  it('should return false if contributors were changed', () => {
+    const newContributorsFormValues = {
+      ...formValues,
+      contributors: [{
+        contributor: formValues.contributors[0].contributor,
+        contributorNameTypeId: 'new contr typw',
+      }],
+    };
+
+    expect(shouldSetInstanceId(newContributorsFormValues, inventoryData)).toBeFalsy();
+  });
+
+  it('should return false if productIds were changed', () => {
+    const newProductIdsFormValues = {
+      ...formValues,
+      details: {
+        productIds: [{
+          productId: 'new id',
+          productIdType: formValues.details.productIds[0].productIdType,
+        }],
+      },
+    };
+
+    expect(shouldSetInstanceId(newProductIdsFormValues, inventoryData)).toBeFalsy();
+  });
+
+  it('should return true if productIds were deleted', () => {
+    const newProductIdsFormValues = {
+      ...formValues,
+      details: {
+        productIds: [formValues.details.productIds[0]],
+      },
+    };
+
+    expect(shouldSetInstanceId(newProductIdsFormValues, inventoryData)).toBeTruthy();
+  });
+
+  it('should return false if productIds were added', () => {
+    const newProductIdsFormValues = {
+      ...formValues,
+      details: {
+        productIds: [
+          ...formValues.details.productIds,
+          {
+            productId: 'new',
+            productIdType: 'new',
+          },
+        ],
+      },
+    };
+
+    expect(shouldSetInstanceId(newProductIdsFormValues, inventoryData)).toBeFalsy();
+  });
+});

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -308,6 +308,7 @@ class POLineForm extends Component {
                       {metadata && <ViewMetaData metadata={metadata} />}
 
                       <ItemForm
+                        formName="POLineForm"
                         formValues={formValues}
                         order={order}
                         contributorNameTypes={contributorNameTypes}
@@ -315,6 +316,7 @@ class POLineForm extends Component {
                         dispatch={dispatch}
                         identifierTypes={identifierTypes}
                         initialValues={initialValues}
+                        stripes={stripes}
                       />
                     </Accordion>
                     <Accordion

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
@@ -270,10 +270,12 @@ class OrderTemplatesEditor extends Component {
                       identifierTypes={identifierTypes}
                       contributorNameTypes={contributorNameTypes}
                       order={ORDER}
+                      formName={ORDER_TEMPLATES_FORM_NAME}
                       formValues={formValues}
                       change={change}
                       dispatch={dispatch}
                       required={false}
+                      stripes={stripes}
                     />
                   </Accordion>
 

--- a/test/bigtest/interactors/line-edit-page.js
+++ b/test/bigtest/interactors/line-edit-page.js
@@ -145,6 +145,7 @@ const ITEM_DETAILS = {
 
   edition = fillable('[name="edition"]');
   publisher = fillable('[name="publisher"]');
+  publicationDate = new TextFieldInteractor('[name="publicationDate"]');
 }
 
 @interactor class OrderFormat {

--- a/test/bigtest/interactors/line-edit-page.js
+++ b/test/bigtest/interactors/line-edit-page.js
@@ -12,7 +12,10 @@ import {
   value,
 } from '@bigtest/interactor';
 
-import { OptionListInteractor } from '@folio/stripes-acq-components/test/bigtest/interactors';
+import {
+  OptionListInteractor,
+  TextFieldInteractor,
+} from '@folio/stripes-acq-components/test/bigtest/interactors';
 
 import Button from './button';
 import { ACCORDION_ID } from '../../../src/components/POLine/const';
@@ -134,7 +137,8 @@ const ITEM_DETAILS = {
   contributorNames = collection(ContributorName.defaultScope);
   contributorName = new ContributorName();
   contributorType = new ContributorType();
-  productIds = collection(ProductId.defaultScope);
+  productIds = collection(ProductId.defaultScope, TextFieldInteractor);
+
   productId = new ProductId();
   productIdTypes = collection(ProductIdType.defaultScope);
   productIdType = new ProductIdType();

--- a/test/bigtest/tests/POLine/line-edit-capture-inventure-uuid-test.js
+++ b/test/bigtest/tests/POLine/line-edit-capture-inventure-uuid-test.js
@@ -130,6 +130,5 @@ describe('Line edit test - Capture UUID from inventory', function () {
         expect(lineEditPage.connectedTitleLabel).to.be.false;
       });
     });
-
   });
 });

--- a/test/bigtest/tests/POLine/line-edit-capture-inventure-uuid-test.js
+++ b/test/bigtest/tests/POLine/line-edit-capture-inventure-uuid-test.js
@@ -92,14 +92,44 @@ describe('Line edit test - Capture UUID from inventory', function () {
     });
   });
 
-  describe('Remove contributor and product id', () => {
+  describe('Remove contributor', () => {
     beforeEach(async function () {
       await lineEditPage.removeContributorButton.click();
-      await lineEditPage.removeProductIdsButton.click();
     });
 
     it('connected link is not shown', () => {
-      expect(lineEditPage.connectedTitleLabel).to.be.false;  // https://issues.folio.org/browse/UIOR-374
+      expect(lineEditPage.connectedTitleLabel).to.be.false;
     });
+  });
+
+  describe('Remove product id', () => {
+    beforeEach(async function () {
+      await lineEditPage.removeProductIdsButton.click();
+    });
+
+    it('shows the connected link', () => {
+      expect(lineEditPage.connectedTitleLabel).to.be.true;
+    });
+  });
+
+  describe('Add product id', () => {
+    beforeEach(async function () {
+      await lineEditPage.addProductIdsButton.click();
+    });
+
+    it('connected link is shown', () => {
+      expect(lineEditPage.connectedTitleLabel).to.be.true;
+    });
+
+    describe('Enter product id', () => {
+      beforeEach(async function () {
+        await lineEditPage.itemDetailsAccordion.productIds(1).fillAndBlur('new');
+      });
+
+      it('connected link is not shown', () => {
+        expect(lineEditPage.connectedTitleLabel).to.be.false;
+      });
+    });
+
   });
 });

--- a/test/bigtest/tests/POLine/line-edit-capture-inventure-uuid-test.js
+++ b/test/bigtest/tests/POLine/line-edit-capture-inventure-uuid-test.js
@@ -70,15 +70,83 @@ describe('Line edit test - Capture UUID from inventory', function () {
     expect(lineEditPage.connectedTitleLabel).to.be.true;
   });
 
-  describe('Remove instance ID from form', () => {
+  describe('Change title', () => {
     beforeEach(async function () {
       await lineEditPage.itemDetailsAccordion.inputTitle('');
+    });
+
+    it('connected link is not shown', () => {
+      expect(lineEditPage.connectedTitleLabel).to.be.false;
+    });
+
+    describe('Return back title', () => {
+      beforeEach(async function () {
+        await lineEditPage.itemDetailsAccordion.inputTitle(TITLE);
+      });
+
+      it('connected link is shown', () => {
+        expect(lineEditPage.connectedTitleLabel).to.be.true;
+      });
+    });
+  });
+
+  describe('Change edition', () => {
+    beforeEach(async function () {
       await lineEditPage.itemDetailsAccordion.edition('');
+    });
+
+    it('connected link is not shown', () => {
+      expect(lineEditPage.connectedTitleLabel).to.be.false;
+    });
+
+    describe('Return back edition', () => {
+      beforeEach(async function () {
+        await lineEditPage.itemDetailsAccordion.edition(EDITION);
+      });
+
+      it('connected link is shown', () => {
+        expect(lineEditPage.connectedTitleLabel).to.be.true;
+      });
+    });
+  });
+
+  describe('Change publisher', () => {
+    beforeEach(async function () {
       await lineEditPage.itemDetailsAccordion.publisher('');
     });
 
     it('connected link is not shown', () => {
       expect(lineEditPage.connectedTitleLabel).to.be.false;
+    });
+
+    describe('Return back publisher', () => {
+      beforeEach(async function () {
+        await lineEditPage.itemDetailsAccordion.publisher(PUBLISHER);
+      });
+
+      it('connected link is shown', () => {
+        expect(lineEditPage.connectedTitleLabel).to.be.true;
+      });
+    });
+  });
+
+  describe('Change publicationDate', () => {
+    beforeEach(async function () {
+      await lineEditPage.itemDetailsAccordion.publicationDate.fillAndBlur('2005');
+    });
+
+    it('connected link is not shown', () => {
+      expect(lineEditPage.connectedTitleLabel).to.be.false;
+    });
+
+    describe('Return back publicationDate', () => {
+      beforeEach(async function () {
+        await lineEditPage.itemDetailsAccordion.publicationDate.fillAndBlur('');
+      });
+
+      it('connected link is shown', () => {
+        expect(lineEditPage.connectedTitleLabel).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Basically, the initial functionality were implemented in this commit year ago
https://github.com/folio-org/ui-orders/blob/ba587fe632d58c3b41ceebb8fcd0fe79133d0b04/src/components/POLine/Item/ItemForm.js#L124
after that it was broken here 10 months ago
https://github.com/folio-org/ui-orders/blob/571b737a6ef191402c68074d4818b662c4313cac/src/components/POLine/Item/ItemForm.js#L121
and more broken logic were committed here
https://github.com/folio-org/ui-orders/blob/5477c1faae9d0c106965613f778b180ffbf53930/src/components/POLine/Item/util.js#L48 
https://issues.folio.org/browse/UIOR-552
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
There was wrong approach on comparing data. It was always involving `initialValues`, that didn't work right when user edit PO Line and select another instance. `getInventoryData` were always merging state of selected inventory data and data from back-end, which is like to merge several instances, what is definitely wrong. I refactored to fill state from initialValues only once on creation time.
https://github.com/folio-org/ui-orders/blob/ba587fe632d58c3b41ceebb8fcd0fe79133d0b04/src/components/POLine/Item/ItemForm.js#L120
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
