### PR TITLE
UIOR-818 upgrade ui-plugin-find-po-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Pieces are not displayed in POL Related invoices table. Refs UIOR-815.
 * Disable/enable instance matching for FOLIO tenant. Refs UIOR-763.
 * Settings (Orders) | Apply baseline keyboard shortcuts. Refs UIOR-803.
+* Use a compatible version of `ui-plugin-find-po-line`. Refs UIOR-818.
 
 ## [3.0.0](https://github.com/folio-org/ui-orders/tree/v3.0.0) (2021-10-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v2.4.2...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -421,7 +421,7 @@
     "sinon": "^7.0.0"
   },
   "dependencies": {
-    "@folio/plugin-find-po-line": "^2.3.0",
+    "@folio/plugin-find-po-line": "^3.0.0",
     "@folio/stripes-acq-components": "~3.0.0",
     "classnames": "^2.2.5",
     "final-form": "^4.19.1",


### PR DESCRIPTION
## Purpose

Use a version of `@folio/plugin-find-po-line` (`v3`) that is
compatible with the current version of `@folio/stripes` (`v7`).

This avoids pulling in multiple copies of various modules that can otherwise be de-duped when hoisting:
```
├─ @folio/orders@3.0.10001122
│  └─ @folio/plugin-find-po-line@2.4.1000106
│     └─ @folio/stripes-acq-components@2.4.3000516
```

Refs [UIOR-818](https://issues.folio.org/browse/UIOR-818)
