### PR TITLE
UIOR-997 do not iterate if locations is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * New invoice action (PO details). Refs UIOR-990.
 * Add icon for Unopen/Reopen order and Update encumbrance. Refs UIOr-998.
 * Orders (settings): View all settings not allowing user to see Instance matching area. Refs UIOR-1004.
+* Do not unconditionally iterate over possibly null value. Refs UIOR-997.
 
 ## [3.2.1](https://github.com/folio-org/ui-orders/tree/v3.2.1) (2022-07-27)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.2.0...v3.2.1)

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -110,7 +110,9 @@ class ItemForm extends Component {
         change('instanceId', inventoryData.instanceId);
       } else {
         change('instanceId', null);
-        locations.forEach((_, i) => change(`locations[${i}].holdingId`, null));
+        if (Array.isArray(locations)) {
+          locations.forEach((_, i) => change(`locations[${i}].holdingId`, null));
+        }
       }
     });
   };

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -110,9 +110,7 @@ class ItemForm extends Component {
         change('instanceId', inventoryData.instanceId);
       } else {
         change('instanceId', null);
-        if (Array.isArray(locations)) {
-          locations.forEach((_, i) => change(`locations[${i}].holdingId`, null));
-        }
+        locations?.forEach((_, i) => change(`locations[${i}].holdingId`, null));
       }
     });
   };


### PR DESCRIPTION
Do not call `list.forEach` if `list` is null. [Line 104 sets `locations`
to a possibly null value](https://github.com/folio-org/ui-orders/blame/8cd095498aca31589d147a32e888073f0d4b72e7/src/components/POLine/Item/ItemForm.js#L101-L116):
```
    const locations = formValues?.locations;
```
and therefore we must validate it before calling methods on it.

This should help unblock #1337.

Refs [UIOR-997](https://issues.folio.org/browse/UIOR-997)