### PR TITLE
UIOR-1017: Support holdings-storage 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * New invoice action (PO details). Refs UIOR-990.
 * Add icon for Unopen/Reopen order and Update encumbrance. Refs UIOr-998.
 * Do not unconditionally iterate over possibly null value. Refs UIOR-997.
+* Support `holdings-storage` `6.0`. Refs UIOR-1017.
 
 ## [3.2.2](https://github.com/folio-org/ui-orders/tree/v3.2.2) (2022-08-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.2.1...v3.2.2)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "finance.expense-classes": "2.0 3.0",
       "finance.funds": "1.0 2.0",
       "finance.transactions": "4.0 5.0",
-      "holdings-storage": "4.4 5.0",
+      "holdings-storage": "4.4 5.0 6.0",
       "identifier-types": "1.2",
       "instance-formats": "2.0",
       "instance-relationship-types": "1.0",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

ui-orders uses only the holdings-storage interface, not the other two.

ui-orders is not affected because the incompatible change is in the DELETE all APIs only.

Only the okapiInterfaces need to be bumped in package.json.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.