### PR TITLE
UIOR-1020: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add icon for Unopen/Reopen order and Update encumbrance. Refs UIOr-998.
 * Do not unconditionally iterate over possibly null value. Refs UIOR-997.
 * Support `holdings-storage` `6.0`. Refs UIOR-1017.
+* Support `inventory` `12.0`. Refs UIOR-1020.
 
 ## [3.2.2](https://github.com/folio-org/ui-orders/tree/v3.2.2) (2022-08-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.2.1...v3.2.2)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "instance-relationship-types": "1.0",
       "instance-statuses": "1.0",
       "instance-types": "2.0",
-      "inventory": "10.10 11.0",
+      "inventory": "10.10 11.0 12.0",
       "invoice": "7.0",
       "loan-types": "2.2",
       "location-units": "2.0",


### PR DESCRIPTION
Add version 12.0 to the list of supported inventory interface versions.

DELETE /inventory/instances and DELETE /inventory/items have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-orders doesn't need any code change because it doesn't use these two DELETE APIs.