### PR TITLE
UIOR-1029 Blanking 'Quantity physical' or 'Quantity electronic' from order template sets property to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Display export details on order view. Refs UIOR-886.
 * Link title MCL is showing blank rows. Refs UIOR-1027.
 * A user with certain permission gets 403 error when viewing order/order line. Refs UIOR-1032.
+* Blanking "Quantity physical" or "Quantity electronic" from order template sets property to empty string. Refs UIOR-1029.
 
 ## [3.2.2](https://github.com/folio-org/ui-orders/tree/v3.2.2) (2022-08-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.2.1...v3.2.2)

--- a/src/components/POLine/Cost/CostForm.js
+++ b/src/components/POLine/Cost/CostForm.js
@@ -14,7 +14,6 @@ import {
   AmountWithCurrencyField,
   CurrencyExchangeRateFields,
   ORDER_FORMATS,
-  parseNumberFieldValue,
   TextField,
   TypeToggle,
   validateRequiredNotNegative,
@@ -118,7 +117,7 @@ const CostForm = ({
       change('cost.fyroAdjustmentAmount', 0);
     }
 
-    change(e.target.name, e.target.value);
+    change(e.target.name, parseNumber(e.target.value));
   };
 
   return (
@@ -138,7 +137,6 @@ const CostForm = ({
                     fullWidth
                     label={<FormattedMessage id={`ui-orders.cost.${isPackageLabel ? 'listPrice' : 'listPriceOfPhysical'}`} />}
                     name="cost.listUnitPrice"
-                    parse={parseNumberFieldValue}
                     type="number"
                     isNonInteractive={isDisabledToChangePaymentInfo}
                     {...validatePhresourcesPrices}
@@ -181,7 +179,6 @@ const CostForm = ({
                 fullWidth
                 label={<FormattedMessage id="ui-orders.cost.additionalCost" />}
                 name="cost.additionalCost"
-                parse={parseNumberFieldValue}
                 type="number"
                 validate={validateNotNegative}
                 isNonInteractive={isDisabledToChangePaymentInfo}
@@ -231,7 +228,6 @@ const CostForm = ({
                     fullWidth
                     label={<FormattedMessage id={`ui-orders.cost.${isPackage ? 'listPrice' : 'unitPriceOfElectronic'}`} />}
                     name="cost.listUnitPriceElectronic"
-                    parse={parseNumberFieldValue}
                     type="number"
                     isNonInteractive={isDisabledToChangePaymentInfo}
                     {...validateEresourcesPrices}
@@ -274,6 +270,7 @@ const CostForm = ({
                 label={<FormattedMessage id="ui-orders.cost.discount" />}
                 name="cost.discount"
                 type="number"
+                parse={parseNumber}
                 validate={validateNotNegative}
                 isNonInteractive={isDisabledToChangePaymentInfo}
               />

--- a/src/components/Utils/parseNumber.js
+++ b/src/components/Utils/parseNumber.js
@@ -1,5 +1,5 @@
 const parseNumber = (value) => {
-  return value && value.length > 0 ? Number(value) : value;
+  return value && value.length > 0 ? Number(value) : null;
 };
 
 export default parseNumber;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-1029
Cleared cost fields return an empty string as value, which is confusing since a number is expected 
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Update parse function to return `null` instead of `""` (empty string) for PO Line cost fields with `number` type.
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
