### PR TITLE
UIOR-1038 Some shortcut keys do not work in the "Orders" app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use Orders Export History API (mod-orders). Refs UIOR-1034.
 * Provide local translations to `ControlledVocab`. Refs UIOR-1018.
+* Some shortcut keys do not work in the "Orders" application. Refs UIOR-1038.
 
 ## [3.3.0](https://github.com/folio-org/ui-orders/tree/v3.3.0) (2022-10-27)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.2.2...v3.3.0)

--- a/src/OrdersList/OrdersList.js
+++ b/src/OrdersList/OrdersList.js
@@ -168,7 +168,7 @@ function OrdersList({
     {
       name: 'new',
       handler: handleKeyCommand(() => {
-        if (stripes.hasPerm('ui-orders.order.create')) {
+        if (stripes.hasPerm('ui-orders.orders.create')) {
           history.push('/orders/create');
         }
       }),

--- a/src/OrdersList/OrdersList.test.js
+++ b/src/OrdersList/OrdersList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { HasCommand } from '@folio/stripes/components';
@@ -22,6 +22,11 @@ const mockLocalStorageFilters = {
   searchIndex: '',
 };
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  // eslint-disable-next-line react/prop-types
+  withRouter: (Component) => (props) => <Component {...props} />,
+}));
 jest.mock('@folio/stripes/smart-components', () => ({
   ...jest.requireActual('@folio/stripes/smart-components'),
   // eslint-disable-next-line react/prop-types
@@ -50,6 +55,9 @@ const defaultProps = {
   resetData: jest.fn(),
   refreshList: jest.fn(),
   history,
+  location: {
+    search: '',
+  },
 };
 
 const renderOrdersList = (props = {}) => render(
@@ -62,6 +70,7 @@ const renderOrdersList = (props = {}) => render(
 
 describe('OrdersList', () => {
   beforeEach(() => {
+    defaultProps.history.push.mockClear();
     HasCommand.mockClear();
     useModalToggle.mockClear();
   });
@@ -97,6 +106,16 @@ describe('OrdersList', () => {
       renderOrdersList();
 
       expect(screen.getByText('OrderExportSettingsModalContainer')).toBeInTheDocument();
+    });
+  });
+
+  describe('shortcuts', () => {
+    it('should handle \'new\' shortcut', async () => {
+      renderOrdersList();
+
+      await act(async () => HasCommand.mock.calls[0][0].commands.find(c => c.name === 'new').handler());
+
+      expect(history.push).toHaveBeenCalled();
     });
   });
 });

--- a/src/common/utils/index.js
+++ b/src/common/utils/index.js
@@ -8,4 +8,5 @@ export * from './getUserNameById';
 export * from './getExportAccountNumbers';
 export * from './getRecordMap';
 export * from './fetchExportDataByIds';
+export * from './omitFieldArraysAsyncErrors';
 export * from './validateDuplicateLines';

--- a/src/common/utils/omitFieldArraysAsyncErrors.js
+++ b/src/common/utils/omitFieldArraysAsyncErrors.js
@@ -1,0 +1,27 @@
+import { ARRAY_ERROR } from 'final-form';
+import {
+  cloneDeep,
+  get,
+  unset,
+} from 'lodash';
+
+/*
+  Final form async validation of field array itself return a Promise instead of resolved value
+  and set it as "FINAL_FORM/array-error". So form always contain this promise in form's
+  errors object even if there no actual validation error.
+
+  Issue: https://github.com/final-form/react-final-form-arrays/issues/176
+*/
+export const omitFieldArraysAsyncErrors = (formErrors, asyncFieldArrays = []) => {
+  const cloned = cloneDeep(formErrors);
+
+  asyncFieldArrays.forEach((field) => {
+    const arrayFieldAsyncError = get(formErrors, `${field}[${ARRAY_ERROR}].then`);
+
+    if (arrayFieldAsyncError && !get(formErrors, field, []).filter(Boolean).length) {
+      unset(cloned, field);
+    }
+  });
+
+  return cloned;
+};

--- a/src/common/utils/omitFieldArraysAsyncErrors.test.js
+++ b/src/common/utils/omitFieldArraysAsyncErrors.test.js
@@ -1,0 +1,49 @@
+import { ARRAY_ERROR } from 'final-form';
+
+import { omitFieldArraysAsyncErrors } from './omitFieldArraysAsyncErrors';
+
+const ASYNC_FIELD_ARRAY = 'fieldArrayWithAsyncValidation';
+
+describe('omitFieldArraysAsyncErrors', () => {
+  it('should omit field-array from form errors if it contains only async error of array itself', () => {
+    const fieldArrayErrors = [];
+
+    fieldArrayErrors[ARRAY_ERROR] = Promise.resolve(null);
+
+    const formErrors = {
+      [ASYNC_FIELD_ARRAY]: fieldArrayErrors,
+    };
+
+    const errors = omitFieldArraysAsyncErrors(formErrors, [ASYNC_FIELD_ARRAY]);
+
+    expect(errors).toEqual({});
+  });
+
+  it('should keep field-array in form errors object if it contains sync error of array itself', () => {
+    const fieldArrayErrors = [];
+
+    fieldArrayErrors[ARRAY_ERROR] = 'Invalid array';
+
+    const formErrors = {
+      [ASYNC_FIELD_ARRAY]: fieldArrayErrors,
+    };
+
+    const errors = omitFieldArraysAsyncErrors(formErrors, [ASYNC_FIELD_ARRAY]);
+
+    expect(ASYNC_FIELD_ARRAY in errors).toBeTruthy();
+  });
+
+  it('should keep field-array in form errors object if it contains its fields\' errors', () => {
+    const fieldArrayErrors = ['Test field is invalid'];
+
+    fieldArrayErrors[ARRAY_ERROR] = Promise.resolve(null);
+
+    const formErrors = {
+      [ASYNC_FIELD_ARRAY]: fieldArrayErrors,
+    };
+
+    const errors = omitFieldArraysAsyncErrors(formErrors, [ASYNC_FIELD_ARRAY]);
+
+    expect(ASYNC_FIELD_ARRAY in errors).toBeTruthy();
+  });
+});

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { get, mapValues, pick } from 'lodash';
 import { FormattedMessage } from 'react-intl';
@@ -39,6 +39,7 @@ import {
   isOtherResource,
 } from '../../common/POLFields';
 import { isOngoing } from '../../common/POFields';
+import { omitFieldArraysAsyncErrors } from '../../common/utils';
 import LocationForm from './Location/LocationForm';
 import { EresourcesForm } from './Eresources';
 import { PhysicalForm } from './Physical';
@@ -276,7 +277,8 @@ function POLineForm({
     );
   };
 
-  const errors = form.getState()?.errors;
+  const formErrors = form.getState()?.errors;
+  const errors = useMemo(() => omitFieldArraysAsyncErrors(formErrors, ['fundDistribution']), [formErrors]);
 
   const [
     expandAll,

--- a/src/components/POLine/POLineView.js
+++ b/src/components/POLine/POLineView.js
@@ -124,6 +124,7 @@ const POLineView = ({
     [ACCORDION_ID.poLine]: true,
     [ACCORDION_ID.linkedInstances]: false,
     [ACCORDION_ID.exportDetails]: false,
+    [ACCORDION_ID.ongoingOrder]: true,
   });
   const [showConfirmDelete, toggleConfirmDelete] = useModalToggle();
   const [showConfirmCancel, toggleConfirmCancel] = useModalToggle();

--- a/src/components/POLine/const.js
+++ b/src/components/POLine/const.js
@@ -58,6 +58,6 @@ export const POL_TEMPLATE_FIELDS_MAP = {
   'tags.tagList': 'polTags.tagList',
 };
 
-export const INITIAL_SECTIONS = Object.keys(ACCORDION_ID).reduce(
+export const INITIAL_SECTIONS = Object.values(ACCORDION_ID).reduce(
   (accum, id) => ({ ...accum, [id]: true }), {},
 );

--- a/src/components/POLine/const.js
+++ b/src/components/POLine/const.js
@@ -32,6 +32,7 @@ export const MAP_FIELD_ACCORDION = {
   details: ACCORDION_ID.itemDetails,
   eresource: ACCORDION_ID.eresources,
   fundDistribution: ACCORDION_ID.fundDistribution,
+  'fundDistribution-error': ACCORDION_ID.fundDistribution,
   locations: ACCORDION_ID.location,
   orderFormat: ACCORDION_ID.lineDetails,
   other: ACCORDION_ID.other,

--- a/src/components/PurchaseOrder/PO.js
+++ b/src/components/PurchaseOrder/PO.js
@@ -648,7 +648,7 @@ const PO = ({
     {
       name: 'new',
       handler: handleKeyCommand(() => {
-        if (stripes.hasPerm('ui-orders.order.create')) {
+        if (stripes.hasPerm('ui-orders.orders.create')) {
           history.push('/orders/create');
         }
       }),
@@ -666,7 +666,7 @@ const PO = ({
     {
       name: 'duplicateRecord',
       handler: handleKeyCommand(() => {
-        if (stripes.hasPerm('ui-orders.order.create')) {
+        if (stripes.hasPerm('ui-orders.orders.create')) {
           toggleCloneConfirmation();
         }
       }),

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { mapValues } from 'lodash';
 
@@ -38,6 +39,7 @@ import {
 } from '../../../common/POLFields';
 import { WORKFLOW_STATUS } from '../../../common/constants';
 import { useFundDistributionValidation } from '../../../common/hooks';
+import { omitFieldArraysAsyncErrors } from '../../../common/utils';
 import { ItemForm } from '../../../components/POLine/Item';
 import { CostForm } from '../../../components/POLine/Cost';
 import { OngoingOrderForm } from '../../../components/POLine/OngoingOrder';
@@ -82,7 +84,8 @@ const OrderTemplatesEditor = ({
   submitting,
 }) => {
   const { validateFundDistributionTotal } = useFundDistributionValidation(formValues);
-  const errors = getState()?.errors;
+  const formErrors = getState()?.errors;
+  const errors = useMemo(() => omitFieldArraysAsyncErrors(formErrors, ['fundDistribution']), [formErrors]);
 
   const [
     expandAll,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-1038
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Update permission name in shortcut handlers
- Update accordions configs
- For `POLineForm` and `OrderTenplatesEditor` forms omit async field-arrays errors, that prevents toggle accordions - there is an [issue](https://github.com/final-form/react-final-form-arrays/issues/176) with async validation of `FieldArray` itself. Async validation of `FundDistributionFieldsFinal` field-array delegates error state to [hidden field](https://github.com/folio-org/stripes-acq-components/blob/master/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinal.js#L249).
<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
