### PR TITLE
UIOR-1047 Add confirmation modal - Break instance connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * User can click Change log icon to view the Change log pane. Refs UIOR-857.
 * Display all versions in change log in fourth pane. Refs UIOR-858.
 * Results List | Hyperlink one column to improve accessibility. Refs UIOR-1021.
+* Add confirmation modal - Break instance connection. Refs UIOR-1047
 
 ## [3.3.2](https://github.com/folio-org/ui-orders/tree/v3.3.2) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.3.1...v3.3.2)

--- a/src/components/POLine/Item/BreakInstanceConnectionModal/BreakInstanceConnectionModal.js
+++ b/src/components/POLine/Item/BreakInstanceConnectionModal/BreakInstanceConnectionModal.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { ConfirmationModal } from '@folio/stripes/components';
+
+export const BreakInstanceConnectionModal = ({
+  onCancel,
+  onConfirm,
+  title,
+}) => {
+  const intl = useIntl();
+
+  const modalLabel = intl.formatMessage({ id: 'ui-orders.breakInstanceConnection.modal.heading' });
+  const message = (
+    <FormattedMessage
+      id="ui-orders.breakInstanceConnection.modal.message"
+      values={{ titleOrPackage: title }}
+    />
+  );
+
+  return (
+    <ConfirmationModal
+      aria-label={modalLabel}
+      id="break-instance-connection-confirmation"
+      confirmLabel={<FormattedMessage id="ui-orders.button.confirm" />}
+      heading={modalLabel}
+      message={message}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      open
+    />
+  );
+};
+
+BreakInstanceConnectionModal.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  title: PropTypes.node.isRequired,
+};

--- a/src/components/POLine/Item/BreakInstanceConnectionModal/BreakInstanceConnectionModal.test.js
+++ b/src/components/POLine/Item/BreakInstanceConnectionModal/BreakInstanceConnectionModal.test.js
@@ -1,0 +1,44 @@
+import user from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { act, render, screen } from '@testing-library/react';
+
+import { BreakInstanceConnectionModal } from './BreakInstanceConnectionModal';
+
+const defaultProps = {
+  title: 'Test title',
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+const renderBreakInstanceConnectionModal = (props = {}) => render(
+  <BreakInstanceConnectionModal
+    {...defaultProps}
+    {...props}
+  />,
+  { wrapper: MemoryRouter },
+);
+
+describe('BreakInstanceConnectionModal', () => {
+  it('should render break instance connection confirmation modal', () => {
+    renderBreakInstanceConnectionModal();
+
+    expect(screen.getByText('ui-orders.breakInstanceConnection.modal.heading')).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.breakInstanceConnection.modal.message')).toBeInTheDocument();
+  });
+
+  it('should call \'onConfirm\' when confirm button was clicked', async () => {
+    renderBreakInstanceConnectionModal();
+
+    await act(async () => user.click(screen.getByRole('button', { name: 'ui-orders.button.confirm' })));
+
+    expect(defaultProps.onConfirm).toHaveBeenCalled();
+  });
+
+  it('should call \'onCancel\' when cancel button was clicked', async () => {
+    renderBreakInstanceConnectionModal();
+
+    await act(async () => user.click(screen.getByRole('button', { name: 'stripes-components.cancel' })));
+
+    expect(defaultProps.onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/POLine/Item/BreakInstanceConnectionModal/index.js
+++ b/src/components/POLine/Item/BreakInstanceConnectionModal/index.js
@@ -1,0 +1,1 @@
+export { BreakInstanceConnectionModal } from './BreakInstanceConnectionModal';

--- a/src/components/POLine/Item/ContributorForm.js
+++ b/src/components/POLine/Item/ContributorForm.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
@@ -17,17 +16,13 @@ import {
 
 const ContributorForm = ({
   onChangeField,
+  onRemoveField,
   disabled,
   isNonInteractive,
   required,
   contributorNameTypes,
 }) => {
   const isEditable = !(disabled || isNonInteractive);
-
-  const removeFields = (fields, index) => {
-    fields.remove(index);
-    onChangeField();
-  };
 
   const renderForm = (elem) => {
     return (
@@ -74,7 +69,7 @@ const ContributorForm = ({
       addLabel={!isEditable ? null : <FormattedMessage id="ui-orders.itemDetails.addContributorBtn" />}
       emptyMessage={!isEditable ? <NoValue /> : <FormattedMessage id="ui-orders.itemDetails.addContributor" />}
       id="contributors"
-      onRemove={removeFields}
+      onRemove={onRemoveField}
       canAdd={isEditable}
       canRemove={isEditable}
       renderField={renderForm}
@@ -84,6 +79,7 @@ const ContributorForm = ({
 
 ContributorForm.propTypes = {
   onChangeField: PropTypes.func.isRequired,
+  onRemoveField: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
   isNonInteractive: PropTypes.bool,
   required: PropTypes.bool,

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -43,6 +43,8 @@ import { TitleField } from './TitleField';
 // import { SubscriptionIntervalField } from './SubscriptionIntervalField';
 import css from './ItemForm.css';
 
+const FIELDS_TO_INTERSEPT_ON_DELETE = ['contributors'];
+
 class ItemForm extends Component {
   static propTypes = {
     change: PropTypes.func.isRequired,
@@ -177,9 +179,10 @@ class ItemForm extends Component {
     const normalizedInventoryData = getNormalizedInventoryData(this.state.inventoryData);
     const fieldName = `${fields.name}[${index}]`;
 
-    // Allow removal of added repeatable field for connected instance
+    // Intercept deletion of connected instance field
     if (
       formValues?.instanceId
+        && FIELDS_TO_INTERSEPT_ON_DELETE.includes(fields.name)
         && isEqual(get(formValues, fieldName), get(normalizedInventoryData, fieldName))
     ) {
       return this.onBreakInstanceConnection()

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -43,7 +43,7 @@ import { TitleField } from './TitleField';
 // import { SubscriptionIntervalField } from './SubscriptionIntervalField';
 import css from './ItemForm.css';
 
-const FIELDS_TO_INTERSEPT_ON_DELETE = ['contributors'];
+const FIELDS_TO_INTERCEPT_ON_DELETE = ['contributors'];
 
 class ItemForm extends Component {
   static propTypes = {
@@ -182,7 +182,7 @@ class ItemForm extends Component {
     // Intercept deletion of connected instance field
     if (
       formValues?.instanceId
-        && FIELDS_TO_INTERSEPT_ON_DELETE.includes(fields.name)
+        && FIELDS_TO_INTERCEPT_ON_DELETE.includes(fields.name)
         && isEqual(get(formValues, fieldName), get(normalizedInventoryData, fieldName))
     ) {
       return this.onBreakInstanceConnection()

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -314,6 +314,7 @@ class ItemForm extends Component {
         <Row>
           <Col xs={12}>
             <TitleField
+              data-testid="titleOrPackage-field"
               label={this.getTitleLabel()}
               isNonInteractive={isPostPendingOrder}
               onChange={this.setTitleOrPackage}

--- a/src/components/POLine/Item/ItemForm.test.js
+++ b/src/components/POLine/Item/ItemForm.test.js
@@ -1,51 +1,80 @@
 import React from 'react';
 import user from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
-import { Form } from 'react-final-form';
+import { act, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
+import { Pluggable } from '@folio/stripes/core';
+import stripesForm from '@folio/stripes/final-form';
+
+import { instance, order, orderLine } from '../../../../test/jest/fixtures';
+import { PRODUCT_ID_TYPE } from '../../../common/constants';
 import ItemForm from './ItemForm';
-import PackagePoLineField from './PackagePoLineField';
-import ContributorForm from './ContributorForm';
-import InstancePlugin from './InstancePlugin';
 
-import { order, orderLine } from '../../../../test/jest/fixtures';
-
-jest.mock('./PackagePoLineField', () => jest.fn().mockReturnValue('PackagePoLineField'));
-jest.mock('./ProductIdDetailsForm', () => jest.fn().mockReturnValue('ProductIdDetailsForm'));
-jest.mock('./ContributorForm', () => jest.fn().mockReturnValue('ContributorForm'));
-jest.mock('./InstancePlugin', () => jest.fn().mockReturnValue('InstancePlugin'));
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  Pluggable: jest.fn(({ children }) => <>{children}</>),
+  stripesConnect: jest.fn(Component => (props) => (
+    <Component
+      {...props}
+      mutator={{
+        validateISBN: { GET: jest.fn(() => Promise.resolve()) },
+      }}
+      resources={{
+        linkedPoLine: { records: [{ id: 'baec48dd-1594-2712-be8f-de336bc83fcc', titleOrPackage: 'Interesting Times' }] },
+      }}
+    />
+  )),
+}));
 
 const defaultProps = {
-  formValues: {
-    packagePoLineId: orderLine.id,
-  },
-  identifierTypes: [{
-    label: 'ISBN',
-    value: 'ISBN',
-  }],
   order,
   required: false,
-  initialValues: {},
-  change: jest.fn(),
-  batch: jest.fn((fn) => fn()),
 };
 
-const renderItemForm = (props = {}) => render(
-  <Form
-    onSubmit={() => jest.fn()}
-    render={() => (
-      <ItemForm
-        {...defaultProps}
-        {...props}
-      />
-    )}
+const contributorNameTypes = [
+  { label: 'Test contributor', value: 'testContributorId' },
+  ...instance.contributors.map(
+    ({ contributorNameTypeId, name }) => ({ label: name, value: contributorNameTypeId }),
+  ),
+];
+
+const identifierTypes = [
+  { label: 'ISSN', value: '3461054f-be78-422d-bd51-4ed9f33c8745' },
+  { label: PRODUCT_ID_TYPE.isbn, value: '8261054f-be78-422d-bd51-4ed9f33c3422' },
+];
+
+const normalizeProps = (WrappedComponent) => {
+  return class extends React.Component {
+    render() {
+      return (
+        <WrappedComponent
+          formValues={this.props.values}
+          {...this.props.form}
+          {...this.props}
+        />
+      );
+    }
+  };
+};
+
+const WrappedItemForm = stripesForm({ subscription: { values: true } })(normalizeProps(ItemForm));
+
+const renderItemForm = (props = {}, initialValues = {}) => render(
+  <WrappedItemForm
+    onSubmit={jest.fn()}
+    initialValues={initialValues}
+    {...defaultProps}
+    {...props}
   />,
+  { wrapper: MemoryRouter },
 );
 
 describe('ItemForm', () => {
+  const selectInstance = async (_instance) => act(async () => Pluggable.mock.calls[0][0].selectInstance(_instance));
+  const selectPackage = async (line) => act(async () => Pluggable.mock.calls[1][0].addLines([line]));
+
   beforeEach(() => {
-    defaultProps.change.mockClear();
-    defaultProps.batch.mockClear();
+    Pluggable.mockClear();
   });
 
   it('should render \'item form\' fields', () => {
@@ -60,18 +89,18 @@ describe('ItemForm', () => {
     expect(screen.getByText('ui-orders.itemDetails.publicationDate')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.itemDetails.publisher')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.itemDetails.edition')).toBeInTheDocument();
-    expect(screen.getByText(/PackagePoLineField/i)).toBeInTheDocument();
-    expect(screen.getByText(/ContributorForm/i)).toBeInTheDocument();
-    expect(screen.getByText(/ProductIdDetailsForm/i)).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.itemDetails.linkPackage')).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.itemDetails.contributors')).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.itemDetails.productIds')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.itemDetails.internalNote')).toBeInTheDocument();
   });
 
-  it('should handle \'package field\' change', () => {
+  it('should handle \'package field\' change', async () => {
     renderItemForm();
 
-    user.click(screen.getByLabelText('ui-orders.poLine.package'));
+    await act(async () => user.click(screen.getByLabelText('ui-orders.poLine.package')));
 
-    expect(defaultProps.batch).toHaveBeenCalled();
+    expect(screen.getByRole('checkbox', { name: 'ui-orders.poLine.package' })).toBeChecked();
   });
 
   it('should handle \'TitleField\' change', () => {
@@ -114,52 +143,221 @@ describe('ItemForm', () => {
     expect(field.value).toBe('some edition');
   });
 
-  it('should call onAddLinkPackage when \'PackagePoLineField\' was selected', () => {
+  it('should handle linked package addition', async () => {
     renderItemForm();
 
-    PackagePoLineField.mock.calls[0][0].onSelectLine([orderLine]);
+    await selectPackage(orderLine);
 
-    expect(defaultProps.change).toHaveBeenCalled();
+    expect(screen.getByRole('textbox', { name: 'ui-orders.itemDetails.linkPackage' }).value).toEqual(orderLine.titleOrPackage);
   });
 
-  it('should call onChangeField when \'ContributorForm\'', async () => {
-    renderItemForm();
+  it('should handle \'ContributorForm\' change', async () => {
+    renderItemForm({ contributorNameTypes });
 
-    await waitFor(() => ContributorForm.mock.calls[0][0].onChangeField('value', 'fieldName'));
+    await act(async () => user.click(screen.getByRole('button', { name: 'ui-orders.itemDetails.addContributorBtn' })));
+    await act(async () => user.selectOptions(screen.getByRole('combobox', { name: 'ui-orders.itemDetails.contributorType' }), [contributorNameTypes[1].value]));
 
-    expect(defaultProps.change).toHaveBeenCalled();
+    expect(screen.getByRole('option', { name: contributorNameTypes[1].label }).selected).toBeTruthy();
   });
 
-  it('should call onAddLinkPackage when \'PackagePoLineField\' was selected', () => {
-    renderItemForm();
+  it('should handle instance addition', async () => {
+    renderItemForm({
+      contributorNameTypes,
+      identifierTypes,
+    });
 
-    PackagePoLineField.mock.calls[0][0].onSelectLine([orderLine]);
+    await selectInstance(instance);
 
-    expect(defaultProps.change).toHaveBeenCalled();
+    expect(screen.getByTestId('titleOrPackage-field')).toHaveValue(instance.title);
+    expect(screen.getByText('ui-orders.itemDetails.connectedTitle')).toBeInTheDocument();
   });
 
-  it('should handle instance addition', () => {
-    const instance = {
-      contributors: [{
-        name: 'name',
-        contributorNameTypeId: 'contributorNameTypeId',
-      }],
-      editions: 'editions',
-      publication: [{
-        publisher: 'publisher',
-      }],
-      title: 'title',
-      identifiers: [{
-        identifierTypeId: 'ISBN',
-        value: 'some value',
-      }],
-      id: 'id',
-    };
+  describe('Connected instance', () => {
+    beforeEach(async () => {
+      renderItemForm({
+        contributorNameTypes,
+        identifierTypes,
+      });
 
-    renderItemForm();
+      await selectInstance(instance);
+    });
 
-    InstancePlugin.mock.calls[0][0].addInstance(instance);
+    describe('Break instance connection modal', () => {
+      const clickConfirmBreakInstanceConnection = async () => {
+        await act(async () => user.click(screen.getByRole('button', { name: 'ui-orders.button.confirm' })));
+      };
+      const clickCancelBreakInstanceConnection = async () => {
+        await act(async () => user.click(screen.getByRole('button', { name: 'stripes-components.cancel' })));
+      };
+      const expectConnectedTitle = () => {
+        expect(screen.getByText('ui-orders.itemDetails.connectedTitle')).toBeInTheDocument();
+      };
+      const expectNotConnectedTitle = () => {
+        expect(screen.getByText('ui-orders.itemDetails.notConnectedTitle')).toBeInTheDocument();
+      };
+      const getDeleteItemBtns = () => screen.getAllByRole('button', { name: 'stripes-components.deleteThisItem' });
 
-    expect(defaultProps.change).toHaveBeenCalled();
+      describe('\'Package\' field', () => {
+        let isPackageCheckbox;
+
+        beforeEach(async () => {
+          isPackageCheckbox = screen.getByRole('checkbox', { name: 'ui-orders.poLine.package' });
+          await act(async () => user.click(isPackageCheckbox));
+        });
+
+        it('should intercept instance connection break on field change', async () => {
+          expect(isPackageCheckbox).toBeChecked();
+          expectConnectedTitle();
+        });
+
+        it('should break instance connection on confirm', async () => {
+          await clickConfirmBreakInstanceConnection();
+
+          expect(isPackageCheckbox).toBeChecked();
+          expectNotConnectedTitle();
+        });
+
+        it('should NOT break instance connection on cancel', async () => {
+          await clickCancelBreakInstanceConnection();
+
+          expect(isPackageCheckbox).not.toBeChecked();
+          expectConnectedTitle();
+        });
+      });
+
+      describe('\'Title\' field', () => {
+        let titleField;
+
+        beforeEach(async () => {
+          titleField = screen.getByTestId('titleOrPackage-field');
+          await act(async () => user.type(titleField, '!'));
+        });
+
+        it('should intercept instance connection break on field change', async () => {
+          expect(titleField).toHaveValue(`${instance.title}!`);
+          expectConnectedTitle();
+        });
+
+        it('should break instance connection on confirm', async () => {
+          await clickConfirmBreakInstanceConnection();
+
+          expect(titleField).toHaveValue(`${instance.title}!`);
+          expectNotConnectedTitle();
+        });
+
+        it('should NOT break instance connection on cancel', async () => {
+          await clickCancelBreakInstanceConnection();
+
+          expect(titleField).toHaveValue(instance.title);
+          expectConnectedTitle();
+        });
+      });
+
+      describe('\'Contributors\' fields', () => {
+        describe('Edit', () => {
+          let contributorTypeField;
+
+          beforeEach(async () => {
+            contributorTypeField = screen.getAllByRole('combobox', { name: 'ui-orders.itemDetails.contributorType' })[0];
+            await act(async () => user.selectOptions(contributorTypeField, [contributorNameTypes[0].value]));
+          });
+
+          it('should break instance connection on confirm', async () => {
+            await clickConfirmBreakInstanceConnection();
+
+            expect(screen.getByRole('option', { name: contributorNameTypes[0].label }).selected).toBeTruthy();
+            expectNotConnectedTitle();
+          });
+
+          it('should NOT break instance connection on cancel', async () => {
+            await clickCancelBreakInstanceConnection();
+
+            expect(screen.getByRole('option', { name: contributorNameTypes[0].label }).selected).toBeFalsy();
+            expectConnectedTitle();
+          });
+        });
+
+        describe('Delete connected', () => {
+          beforeEach(async () => {
+            await act(async () => user.click(screen.getAllByRole('button', { name: 'stripes-components.deleteThisItem' })[0]));
+          });
+
+          it('should intercept instance connection break on field delete', async () => {
+            expect(screen.getByText('ui-orders.breakInstanceConnection.modal.heading')).toBeInTheDocument();
+            expect(screen.getByText(contributorNameTypes[0].label)).toBeInTheDocument();
+            expectConnectedTitle();
+          });
+
+          it('should break instance connection on confirm', async () => {
+            await clickConfirmBreakInstanceConnection();
+
+            expect(screen.queryByText(contributorNameTypes[0].label)).not.toBeInTheDocument();
+            expectNotConnectedTitle();
+          });
+
+          it('should NOT break instance connection on cancel', async () => {
+            await clickCancelBreakInstanceConnection();
+
+            expect(screen.getByText(contributorNameTypes[0].label)).toBeInTheDocument();
+            expectConnectedTitle();
+          });
+        });
+
+        describe('Delete added', () => {
+          it('should NOT intercept instance connection break on field delete', async () => {
+            await act(async () => user.click(screen.getByRole('button', { name: 'ui-orders.itemDetails.addContributorBtn' })));
+
+            const deleteIBtns = getDeleteItemBtns();
+            const deleteContributorBtns = deleteIBtns.slice(0, orderLine.contributors.length + 1);
+
+            await act(async () => user.click(deleteContributorBtns[deleteContributorBtns.length - 1]));
+
+            expect(screen.queryByText('ui-orders.breakInstanceConnection.modal.heading')).not.toBeInTheDocument();
+            expect(getDeleteItemBtns().length).toEqual(deleteIBtns.length - 1);
+            expectConnectedTitle();
+          });
+        });
+      });
+
+      describe('\'Product identifiers\' fields', () => {
+        describe('Edit', () => {
+          let productIdField;
+
+          beforeEach(async () => {
+            productIdField = screen.getAllByRole('combobox', { name: 'ui-orders.itemDetails.productIdType' })[0];
+            await act(async () => user.selectOptions(productIdField, [identifierTypes[0].value]));
+          });
+
+          it('should break instance connection on confirm', async () => {
+            await clickConfirmBreakInstanceConnection();
+
+            expect(screen.getByRole('option', { name: identifierTypes[0].label }).selected).toBeTruthy();
+            expectNotConnectedTitle();
+          });
+
+          it('should NOT break instance connection on cancel', async () => {
+            await clickCancelBreakInstanceConnection();
+
+            expect(screen.getByRole('option', { name: identifierTypes[0].label }).selected).toBeFalsy();
+            expectConnectedTitle();
+          });
+        });
+
+        describe('Delete', () => {
+          it('should NOT intercept instance connection break on field delete', async () => {
+            await act(async () => user.click(screen.getByRole('button', { name: 'ui-orders.itemDetails.addProductIdBtn' })));
+
+            const deleteBtns = getDeleteItemBtns();
+            const deleteProductIdBtns = deleteBtns.slice(orderLine.contributors.length);
+
+            await act(async () => user.click(deleteProductIdBtns[deleteProductIdBtns.length - 1]));
+
+            expect(screen.queryByText('ui-orders.breakInstanceConnection.modal.heading')).not.toBeInTheDocument();
+            expect(getDeleteItemBtns().length).toEqual(deleteBtns.length - 1);
+            expectConnectedTitle();
+          });
+        });
+      });
+    });
   });
 });

--- a/src/components/POLine/Item/ProductIdDetailsForm.js
+++ b/src/components/POLine/Item/ProductIdDetailsForm.js
@@ -32,15 +32,13 @@ function ProductIdDetailsForm({
   isNonInteractive,
   mutator,
   onChangeField,
+  onRemoveField,
   required,
 }) {
   const isEditable = !(disabled || isNonInteractive);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedMutator = useMemo(() => mutator, []);
-  const removeField = useCallback((fields, index) => {
-    fields.remove(index);
-    onChangeField();
-  }, [onChangeField]);
+
   const callValidationAPI = useCallback(
     (isbn) => memoizedMutator.validateISBN.GET({ params: { isbn } }),
     [memoizedMutator.validateISBN],
@@ -132,7 +130,7 @@ function ProductIdDetailsForm({
       id="productIds"
       legend={<FormattedMessage id="ui-orders.itemDetails.productIds" />}
       name="details.productIds"
-      onRemove={removeField}
+      onRemove={onRemoveField}
       canAdd={isEditable}
       canRemove={isEditable}
       renderField={renderSubForm}
@@ -144,6 +142,7 @@ ProductIdDetailsForm.propTypes = {
   identifierTypes: PropTypes.arrayOf(PropTypes.object),
   isNonInteractive: PropTypes.bool,
   onChangeField: PropTypes.func.isRequired,
+  onRemoveField: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
   mutator: PropTypes.object,

--- a/src/components/POLine/Item/util.js
+++ b/src/components/POLine/Item/util.js
@@ -31,24 +31,19 @@ export const getNormalizedInventoryData = (inventoryData) => {
 
 // It compares actual form data (formValues) to contain data came from inventory or initial get request (inventoryData)
 export const shouldSetInstanceId = (formValues, inventoryData) => {
-  const formContributors = get(formValues, 'contributors', []);
+  const isEqualContributors = inventoryData.contributors.every(el => {
+    const contributor = find(get(formValues, 'contributors', []), { 'contributor': el.contributor });
+
+    return contributor ? isEqual(contributor, el) : false;
+  });
+
   const formProductIds = get(formValues, 'details.productIds', []);
 
-  const isEqualContributors = (
-    (formContributors.length === inventoryData.contributors?.length) && inventoryData.contributors.every(el => {
-      const contributor = find(get(formValues, 'contributors', []), { 'contributor': el.contributor });
+  const isEqualProductIds = formProductIds.every(item => {
+    const productId = find(inventoryData.productIds, { 'productId': item.productId });
 
-      return contributor ? isEqual(contributor, el) : false;
-    })
-  );
-
-  const isEqualProductIds = (
-    (formProductIds.length === inventoryData.productIds?.length) && formProductIds.every(item => {
-      const productId = find(inventoryData.productIds, { 'productId': item.productId });
-
-      return productId ? isEqual(productId, item) : false;
-    })
-  );
+    return productId ? isEqual(productId, item) : false;
+  });
 
   return (
     inventoryData.instanceId

--- a/src/components/POLine/Item/util.js
+++ b/src/components/POLine/Item/util.js
@@ -19,21 +19,36 @@ export const getInventoryData = (initialValues) => {
   };
 };
 
+export const getNormalizedInventoryData = (inventoryData) => {
+  const { productIds, title, ...data } = inventoryData;
+
+  return {
+    titleOrPackage: title,
+    details: { productIds },
+    ...data,
+  };
+};
+
 // It compares actual form data (formValues) to contain data came from inventory or initial get request (inventoryData)
 export const shouldSetInstanceId = (formValues, inventoryData) => {
-  const isEqualContributors = inventoryData.contributors.every(el => {
-    const contributor = find(get(formValues, 'contributors', []), { 'contributor': el.contributor });
-
-    return contributor ? isEqual(contributor, el) : false;
-  });
-
+  const formContributors = get(formValues, 'contributors', []);
   const formProductIds = get(formValues, 'details.productIds', []);
 
-  const isEqualProductIds = formProductIds.every(item => {
-    const productId = find(inventoryData.productIds, { 'productId': item.productId });
+  const isEqualContributors = (
+    (formContributors.length === inventoryData.contributors?.length) && inventoryData.contributors.every(el => {
+      const contributor = find(get(formValues, 'contributors', []), { 'contributor': el.contributor });
 
-    return productId ? isEqual(productId, item) : false;
-  });
+      return contributor ? isEqual(contributor, el) : false;
+    })
+  );
+
+  const isEqualProductIds = (
+    (formProductIds.length === inventoryData.productIds?.length) && formProductIds.every(item => {
+      const productId = find(inventoryData.productIds, { 'productId': item.productId });
+
+      return productId ? isEqual(productId, item) : false;
+    })
+  );
 
   return (
     inventoryData.instanceId

--- a/translations/ui-orders/en.json
+++ b/translations/ui-orders/en.json
@@ -1,6 +1,9 @@
 {
   "appMenu.ordersAppSearch": "Orders app Search",
 
+  "breakInstanceConnection.modal.heading": "Remove instance connection",
+  "breakInstanceConnection.modal.message": "Making this change will remove the link between the POL and selected inventory instance. Are you sure you would like to proceed with making this change and unlink this POL from the inventory instance \"<b>{titleOrPackage}</b>\"?",
+
   "deletePiece.btn.cancel": "Cancel",
   "deletePiece.btn.deletePiece": "Delete",
   "deletePiece.title": "Piece(s) to be deleted",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
Show confirmation modal before breaking instance connection and applying change to instance related field
https://issues.folio.org/browse/UIOR-1047
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- add `<BreakInstanceConnectionModal />` component
- update handlers for fields changing and deletion (add ability to handle changes asynchronously)
- use JS Promise `resolve` and `reject` as modal `Confirm` and `Cancel` handlers accordingly for declarative processing
- unit tests

![chrome_KyuMpGExbK](https://user-images.githubusercontent.com/88109087/208412196-550d905b-abc1-47ee-98ca-2f4a728ffcdf.gif)

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
