### PR TITLE
UIOR-1070 UIOR-1071 UIOR-1072 Fix displayed values on order version history view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Map missed error codes with new translations. Refs UIOR-1054.
 * Align the `Created by` and `Created on` fields with BE changes. Refs UIOR-1065.
 * *BREAKING*: Update `@folio/stripes` to `8.0.0`. Refs UIOR-1062.
+* Display correct value for `Manual` checkbox in Order version history view. Refs UIOR-1070.
+* Use proper date formatting for "Approval date" value. Refs UIOR-1071.
 
 ## [3.3.2](https://github.com/folio-org/ui-orders/tree/v3.3.2) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.3.1...v3.3.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 * Map missed error codes with new translations. Refs UIOR-1054.
 * Align the `Created by` and `Created on` fields with BE changes. Refs UIOR-1065.
 * *BREAKING*: Update `@folio/stripes` to `8.0.0`. Refs UIOR-1062.
-* Display correct value for `Manual` checkbox in Order version history view. Refs UIOR-1070.
+* Display correct value for `Manual` checkbox on order version history view. Refs UIOR-1070.
 * Use proper date formatting for "Approval date" value. Refs UIOR-1071.
+* Display correct values for `Reason for closure` and `Notes on closure` fields on order version history view. Refs UIOR-1072.
 
 ## [3.3.2](https://github.com/folio-org/ui-orders/tree/v3.3.2) (2022-11-30)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v3.3.1...v3.3.2)

--- a/src/components/POLine/POLineVersionView/EresourcesVersionView/EresourcesVersionView.js
+++ b/src/components/POLine/POLineVersionView/EresourcesVersionView/EresourcesVersionView.js
@@ -41,7 +41,7 @@ export const EresourcesVersionView = ({ version }) => {
 
       <Col xs={3}>
         <VersionCheckbox
-          name="eresource.activationStatus"
+          name="eresource.activated"
           checked={eresource?.activated}
           label={<FormattedMessage id="ui-orders.eresource.activationStatus" />}
         />
@@ -97,7 +97,7 @@ export const EresourcesVersionView = ({ version }) => {
 
       <Col xs={3}>
         <VersionKeyValue
-          name="eresource.url"
+          name="eresource.resourceUrl"
           label={<FormattedMessage id="ui-orders.eresource.url" />}
           value={resourceUrl}
         />

--- a/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
+++ b/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext } from 'react';
 
-import { KeyValue } from '@folio/stripes/components';
 import {
-  getHighlightedFields,
+  KeyValue,
+  NoValue,
+} from '@folio/stripes/components';
+import {
   VersionViewContext,
 } from '@folio/stripes-acq-components';
 
@@ -17,17 +19,9 @@ export const LocationVersionView = ({ version }) => {
   const locations = version?.locations;
   const locationsList = version?.locationsList;
 
-  const highlights = useMemo(() => (
-    getHighlightedFields({
-      changes: versionContext?.changes,
-      fieldNames: ['locationId', 'holdingId', 'quantityPhysical', 'quantityElectronic'],
-      name: LOCATIONS_NAME,
-    })
-  ), [versionContext?.changes]);
-
   const renderKeyValueComponent = useCallback(({ name, value, ...props }) => {
-    const isUpdated = highlights?.includes(name);
-    const displayValue = isUpdated ? <mark>{value}</mark> : value;
+    const isUpdated = versionContext?.paths?.includes(name);
+    const displayValue = isUpdated ? <mark>{value || <NoValue />}</mark> : value;
 
     return (
       <KeyValue
@@ -35,7 +29,7 @@ export const LocationVersionView = ({ version }) => {
         value={displayValue}
       />
     );
-  }, [highlights]);
+  }, [versionContext?.paths]);
 
   return (
     <LocationView

--- a/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.test.js
+++ b/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.test.js
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { VersionViewContextProvider } from '@folio/stripes-acq-components';
+
+import { orderLine } from '../../../../../test/jest/fixtures';
+import { ORDER_LINES_ROUTE } from '../../../../common/constants';
+import { LocationVersionView } from './LocationVersionView';
+
+jest.mock('@folio/stripes-acq-components', () => {
+  return {
+    ...jest.requireActual('@folio/stripes-acq-components'),
+    useLineHoldings: jest.fn().mockReturnValue({
+      isLoading: false,
+      holdings: [{ id: 'holdingId' }],
+    }),
+  };
+});
+
+const versions = [
+  {
+    id: 'version-2',
+    snapshot: {
+      locations: [{
+        locationId: 'location-1-id',
+        quantityPhysical: 1,
+        quantity: 1,
+      }],
+    },
+  },
+  {
+    id: 'version-1',
+    snapshot: {
+      locations: [{
+        locationId: 'location-1-id',
+        quantityPhysical: 2,
+        quantityElectronic: 1,
+        quantity: 3,
+      }],
+    },
+  },
+];
+
+const defaultProps = {
+  version: versions[0].snapshot,
+};
+
+const contextValues = {
+  snapshotPath: 'snapshot',
+  versionId: versions[0].id,
+  versions,
+};
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <VersionViewContextProvider {...contextValues}>
+    <MemoryRouter
+      initialEntries={[{
+        pathname: `${ORDER_LINES_ROUTE}/view/${orderLine.id}/versions/${versions[0].id}`,
+      }]}
+    >
+      {children}
+    </MemoryRouter>
+  </VersionViewContextProvider>
+);
+
+const renderLocationVersionView = (props = {}) => render(
+  <LocationVersionView
+    {...defaultProps}
+    {...props}
+  />,
+  { wrapper },
+);
+
+describe('LocationVersionView', () => {
+  it('should render location version view with highlighted updates', () => {
+    renderLocationVersionView();
+
+    expect(screen.getByText(versions[0].snapshot.locations[0].quantityPhysical)).toBeInTheDocument();
+    expect(screen.getByText(versions[0].snapshot.locations[0].quantityPhysical).tagName.toLocaleLowerCase()).toBe('mark');
+  });
+});

--- a/src/components/POLine/utils.js
+++ b/src/components/POLine/utils.js
@@ -203,6 +203,6 @@ export const getPoLineFieldsLabelMap = ({
     'eresource.trial': 'ui-orders.eresource.trial',
     'eresource.expectedActivation': 'ui-orders.eresource.expectedActivation',
     'eresource.userLimit': 'ui-orders.eresource.userLimit',
-    'eresource.url': 'ui-orders.eresource.url',
+    'eresource.resourceUrl': 'ui-orders.eresource.url',
   };
 };

--- a/src/components/PurchaseOrder/POVersionView/PODetailsVersionView/PODetailsVersionView.js
+++ b/src/components/PurchaseOrder/POVersionView/PODetailsVersionView/PODetailsVersionView.js
@@ -74,7 +74,7 @@ export const PODetailsVersionView = ({ version }) => {
           <VersionKeyValue
             name="approvalDate"
             label={<FormattedMessage id="ui-orders.orderDetails.approvalDate" />}
-            value={version?.approvalDate}
+            value={<FolioFormattedTime dateString={version?.approvalDate} />}
           />
         </Col>
         <Col
@@ -117,7 +117,7 @@ export const PODetailsVersionView = ({ version }) => {
           <VersionCheckbox
             name="manualPo"
             label={<FormattedMessage id="ui-orders.orderDetails.manualPO" />}
-            checked={version?.manualPO}
+            checked={version?.manualPo}
           />
         </Col>
         <Col

--- a/src/components/PurchaseOrder/POVersionView/SummaryVersionView/SummaryVersionView.js
+++ b/src/components/PurchaseOrder/POVersionView/SummaryVersionView/SummaryVersionView.js
@@ -11,6 +11,7 @@ import {
   ORDER_STATUS_LABEL,
 } from '@folio/stripes-acq-components';
 
+import { DEFAULT_CLOSE_ORDER_REASONS } from '../../../../common/constants';
 import {
   VersionCheckbox,
   VersionKeyValue,
@@ -103,14 +104,19 @@ export const SummaryVersionView = ({ version }) => {
             <VersionKeyValue
               name="closeReason.reason"
               label={<FormattedMessage id="ui-orders.orderSummary.closingReason" />}
-              value={<AmountWithCurrencyField amount={version?.closeReason?.reason} />}
+              value={(
+                <FormattedMessage
+                  id={`ui-orders.closeOrderModal.closingReasons.${DEFAULT_CLOSE_ORDER_REASONS[version?.closeReason?.reason]}`}
+                  defaultMessage={version?.closeReason?.reason}
+                />
+              )}
             />
           </Col>
           <Col xs={6}>
             <VersionKeyValue
               name="closeReason.note"
               label={<FormattedMessage id="ui-orders.orderSummary.closingNote" />}
-              value={<AmountWithCurrencyField amount={version?.closeReason?.note} />}
+              value={version?.closeReason?.note}
             />
           </Col>
         </Row>

--- a/src/components/PurchaseOrder/POVersionView/SummaryVersionView/SummaryVersionView.js
+++ b/src/components/PurchaseOrder/POVersionView/SummaryVersionView/SummaryVersionView.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Col,
+  NoValue,
   Row,
 } from '@folio/stripes/components';
 import {
@@ -16,6 +17,17 @@ import {
   VersionCheckbox,
   VersionKeyValue,
 } from '../../../../common/VersionView';
+
+const getClosingReasonValue = (reason) => {
+  if (!reason) return <NoValue />;
+
+  return (
+    <FormattedMessage
+      id={`ui-orders.closeOrderModal.closingReasons.${DEFAULT_CLOSE_ORDER_REASONS[reason]}`}
+      defaultMessage={reason}
+    />
+  );
+};
 
 export const SummaryVersionView = ({ version }) => {
   return (
@@ -104,19 +116,14 @@ export const SummaryVersionView = ({ version }) => {
             <VersionKeyValue
               name="closeReason.reason"
               label={<FormattedMessage id="ui-orders.orderSummary.closingReason" />}
-              value={(
-                <FormattedMessage
-                  id={`ui-orders.closeOrderModal.closingReasons.${DEFAULT_CLOSE_ORDER_REASONS[version?.closeReason?.reason]}`}
-                  defaultMessage={version?.closeReason?.reason}
-                />
-              )}
+              value={getClosingReasonValue(version.closeReason?.reason)}
             />
           </Col>
           <Col xs={6}>
             <VersionKeyValue
               name="closeReason.note"
               label={<FormattedMessage id="ui-orders.orderSummary.closingNote" />}
-              value={version?.closeReason?.note}
+              value={version.closeReason?.note}
             />
           </Col>
         </Row>

--- a/src/components/PurchaseOrder/POVersionView/SummaryVersionView/SummaryVersionView.test.js
+++ b/src/components/PurchaseOrder/POVersionView/SummaryVersionView/SummaryVersionView.test.js
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  VersionViewContextProvider,
+  ORDER_STATUSES,
+} from '@folio/stripes-acq-components';
+
+import { order } from '../../../../../test/jest/fixtures';
+import { ORDERS_ROUTE } from '../../../../common/constants';
+import { SummaryVersionView } from './SummaryVersionView';
+
+const versions = [
+  {
+    id: 'version-2',
+    snapshot: {
+      workflowStatus: ORDER_STATUSES.closed,
+      closeReason: {
+        reason: 'Cancelled',
+        note: 'Test',
+      },
+    },
+  },
+  {
+    id: 'version-1',
+    snapshot: {
+      workflowStatus: ORDER_STATUSES.open,
+    },
+  },
+];
+
+const defaultProps = {
+  version: versions[0].snapshot,
+};
+
+const contextValues = {
+  snapshotPath: 'snapshot',
+  versionId: versions[0].id,
+  versions,
+};
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <VersionViewContextProvider {...contextValues}>
+    <MemoryRouter
+      initialEntries={[{
+        pathname: `${ORDERS_ROUTE}/view/${order.id}/versions/${versions[0].id}`,
+      }]}
+    >
+      {children}
+    </MemoryRouter>
+  </VersionViewContextProvider>
+);
+
+const renderSummaryVersionView = (props = {}) => render(
+  <SummaryVersionView
+    {...defaultProps}
+    {...props}
+  />,
+  { wrapper },
+);
+
+describe('SummaryVersionView', () => {
+  describe('Closing reason', () => {
+    it('should render closing reason value', () => {
+      renderSummaryVersionView();
+
+      expect(screen.getByText('ui-orders.orderSummary.closingReason').nextSibling.textContent).toBe('ui-orders.closeOrderModal.closingReasons.cancelled');
+    });
+
+    it('should display <NoValue /> component when the closing reason is not provided', () => {
+      renderSummaryVersionView({ version: { ...defaultProps.version, closeReason: undefined } });
+
+      expect(screen.getByText('ui-orders.orderSummary.closingReason').nextSibling.textContent).toBe('stripes-components.noValue.noValueSet-');
+    });
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-1070
https://issues.folio.org/browse/UIOR-1071
https://issues.folio.org/browse/UIOR-1072
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- update field name of `Manual` checkbox (UIOR-1070)
- use common component to format `Approval date` as a date (UIOR-1071)
- fix displayed values for `Reason for closure` and `Notes on closure` fields (UIOR-1072)
- fix displayed values for `Activation status` and `URL` fields (e-resources)
- fix highlights of locations component

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
