### PR TITLE
UIOR-1103 Some values are displayed by default in 'View' mode for empty fields in the order template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Keyboard shortcuts issues. Refs UIOR-1086.
 * A user can save duplicated order template name with only spaces before and after initial template name. Refs UIOR-1114.
 * Support new error `multipleFiscalYears` code. Refs UIOR-1104.
+* Some values are displayed by default in "View" mode for empty fields in the order template. Refs UIOR-1103.
 
 ## [4.0.2](https://github.com/folio-org/ui-orders/tree/v4.0.2) (2023-03-17)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v4.0.1...v4.0.2)

--- a/src/common/hooks/index.js
+++ b/src/common/hooks/index.js
@@ -1,3 +1,4 @@
+export * from './useAcqMethod';
 export * from './useAcqMethods';
 export * from './useErrorAccordionStatus';
 export { default as useCloseReasonOptions } from './useCloseReasonOptions';

--- a/src/common/hooks/useAcqMethod/index.js
+++ b/src/common/hooks/useAcqMethod/index.js
@@ -1,0 +1,1 @@
+export { useAcqMethod } from './useAcqMethod';

--- a/src/common/hooks/useAcqMethod/useAcqMethod.js
+++ b/src/common/hooks/useAcqMethod/useAcqMethod.js
@@ -14,7 +14,7 @@ export const useAcqMethod = (methodId, options = {}) => {
     [namespace, methodId],
     () => ky.get(`${ACQUISITION_METHODS_API}/${methodId}`).json(),
     {
-      enabled: methodId,
+      enabled: Boolean(methodId),
       ...options,
     },
   );

--- a/src/common/hooks/useAcqMethod/useAcqMethod.js
+++ b/src/common/hooks/useAcqMethod/useAcqMethod.js
@@ -1,0 +1,26 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+} from '@folio/stripes/core';
+import { ACQUISITION_METHODS_API } from '@folio/stripes-acq-components';
+
+export const useAcqMethod = (methodId, options = {}) => {
+  const ky = useOkapiKy();
+  const [namespace] = useNamespace();
+
+  const { isLoading, data } = useQuery(
+    [namespace, methodId],
+    () => ky.get(`${ACQUISITION_METHODS_API}/${methodId}`).json(),
+    {
+      enabled: methodId,
+      ...options,
+    },
+  );
+
+  return ({
+    acqMethod: data,
+    isLoading,
+  });
+};

--- a/src/common/hooks/useAcqMethod/useAcqMethod.test.js
+++ b/src/common/hooks/useAcqMethod/useAcqMethod.test.js
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { useAcqMethod } from './useAcqMethod';
+
+const queryClient = new QueryClient();
+
+const acqMethod = { id: 'acqMethodId', value: 'ACQ Method' };
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useAcqMethod', () => {
+  beforeEach(() => {
+    useOkapiKy
+      .mockClear()
+      .mockReturnValue({
+        get: () => ({
+          json: () => Promise.resolve(acqMethod),
+        }),
+      });
+  });
+
+  it('should fetch acq method by id', async () => {
+    const { result, waitFor } = renderHook(() => useAcqMethod(acqMethod.id), { wrapper });
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(result.current.acqMethod).toEqual(acqMethod);
+  });
+});

--- a/src/common/hooks/useAcqMethods/useAcqMethods.js
+++ b/src/common/hooks/useAcqMethods/useAcqMethods.js
@@ -25,10 +25,7 @@ export const useAcqMethods = (options = {}) => {
     data = DEFAULT_DATA,
   } = useQuery(
     [namespace, 'acq-methods'],
-    () => ky.get(
-      ACQUISITION_METHODS_API,
-      { searchParams },
-    ).json(),
+    () => ky.get(ACQUISITION_METHODS_API, { searchParams }).json(),
     options,
   );
 

--- a/src/common/hooks/useAcqMethods/useAcqMethods.js
+++ b/src/common/hooks/useAcqMethods/useAcqMethods.js
@@ -1,30 +1,39 @@
 import { useQuery } from 'react-query';
 
-import { useOkapiKy } from '@folio/stripes/core';
-
+import {
+  useNamespace,
+  useOkapiKy,
+} from '@folio/stripes/core';
 import {
   ACQUISITION_METHODS_API,
   LIMIT_MAX,
 } from '@folio/stripes-acq-components';
 
-export const useAcqMethods = (methodId) => {
+const DEFAULT_DATA = [];
+
+export const useAcqMethods = (options = {}) => {
   const ky = useOkapiKy();
+  const [namespace] = useNamespace();
 
   const searchParams = {
     limit: LIMIT_MAX,
     query: 'cql.allRecords=1 sortby value',
   };
 
-  const { isLoading, data } = useQuery(
-    ['ui-orders', 'acq-methods', methodId],
+  const {
+    isLoading,
+    data = DEFAULT_DATA,
+  } = useQuery(
+    [namespace, 'acq-methods'],
     () => ky.get(
-      methodId ? `${ACQUISITION_METHODS_API}/${methodId}` : ACQUISITION_METHODS_API,
+      ACQUISITION_METHODS_API,
       { searchParams },
-    ).json().catch(() => null),
+    ).json(),
+    options,
   );
 
   return ({
-    acqMethods: (methodId ? [data] : data?.acquisitionMethods) ?? [],
+    acqMethods: data?.acquisitionMethods,
     isLoading,
   });
 };

--- a/src/components/POLine/POLineDetails/POLineDetails.js
+++ b/src/components/POLine/POLineDetails/POLineDetails.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import {
   FormattedMessage,
 } from 'react-intl';
-import { get } from 'lodash';
+import {
+  get,
+  isNil,
+} from 'lodash';
 
 import { ClipCopy } from '@folio/stripes/smart-components';
 import {
@@ -20,19 +23,33 @@ import {
   sourceLabels,
 } from '@folio/stripes-acq-components';
 
-import { useAcqMethods } from '../../../common/hooks';
+import { useAcqMethod } from '../../../common/hooks';
 import { IfVisible } from '../../../common/IfVisible';
 import { getTranslatedAcqMethod } from '../../Utils/getTranslatedAcqMethod';
 
 const invalidAcqMethod = <FormattedMessage id="ui-orders.acquisitionMethod.invalid" />;
 
+const getReceivingWorkflowValue = (checkinItems) => {
+  if (isNil(checkinItems)) return null;
+
+  return (
+    <FormattedMessage
+      id={`ui-orders.poLine.receivingWorkflow.${checkinItems ? 'independent' : 'synchronized'}`}
+    />
+  );
+};
+
+const getAcquisitionMethodValue = (acqMethodId, acqMethod) => {
+  if (!acqMethodId) return null;
+
+  return acqMethod
+    ? getTranslatedAcqMethod(acqMethod.value)
+    : invalidAcqMethod;
+};
+
 const POLineDetails = ({ line, hiddenFields }) => {
   const receiptDate = get(line, 'receiptDate');
-  const { acqMethods, isLoading } = useAcqMethods(line.acquisitionMethod);
-
-  const translatedAcqMethod = (!isLoading && acqMethods[0])
-    ? getTranslatedAcqMethod(acqMethods[0].value)
-    : invalidAcqMethod;
+  const { acqMethod, isLoading } = useAcqMethod(line.acquisitionMethod);
 
   return (
     <>
@@ -62,7 +79,7 @@ const POLineDetails = ({ line, hiddenFields }) => {
           >
             <KeyValue
               label={<FormattedMessage id="ui-orders.poLine.acquisitionMethod" />}
-              value={isLoading ? <Loading /> : translatedAcqMethod}
+              value={isLoading ? <Loading /> : getAcquisitionMethodValue(line.acquisitionMethod, acqMethod)}
             />
           </Col>
         </IfVisible>
@@ -247,7 +264,7 @@ const POLineDetails = ({ line, hiddenFields }) => {
           >
             <KeyValue
               label={<FormattedMessage id="ui-orders.poLine.receivingWorkflow" />}
-              value={<FormattedMessage id={`ui-orders.poLine.receivingWorkflow.${line.checkinItems ? 'independent' : 'synchronized'}`} />}
+              value={getReceivingWorkflowValue(line.checkinItems)}
             />
           </Col>
         </IfVisible>

--- a/src/components/POLine/POLineDetails/POLineDetails.js
+++ b/src/components/POLine/POLineDetails/POLineDetails.js
@@ -29,7 +29,7 @@ import { getTranslatedAcqMethod } from '../../Utils/getTranslatedAcqMethod';
 
 const invalidAcqMethod = <FormattedMessage id="ui-orders.acquisitionMethod.invalid" />;
 
-const getReceivingWorkflowValue = (checkinItems) => {
+export const getReceivingWorkflowValue = (checkinItems) => {
   if (isNil(checkinItems)) return null;
 
   return (
@@ -39,7 +39,7 @@ const getReceivingWorkflowValue = (checkinItems) => {
   );
 };
 
-const getAcquisitionMethodValue = (acqMethodId, acqMethod) => {
+export const getAcquisitionMethodValue = (acqMethodId, acqMethod) => {
   if (!acqMethodId) return null;
 
   return acqMethod

--- a/src/components/POLine/POLineDetails/POLineDetails.test.js
+++ b/src/components/POLine/POLineDetails/POLineDetails.test.js
@@ -1,8 +1,14 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { render, screen } from '@testing-library/react';
 
-import POLineDetails from './POLineDetails';
+import { ACQUISITION_METHOD } from '@folio/stripes-acq-components';
+
+import POLineDetails, {
+  getAcquisitionMethodValue,
+  getReceivingWorkflowValue,
+} from './POLineDetails';
 
 const queryClient = new QueryClient();
 
@@ -41,5 +47,43 @@ describe('POLineDetails', () => {
     expect(screen.getByText('ui-orders.poLine.receivingWorkflow')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.cancellationRestrictionNote')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.poLineDescription')).toBeInTheDocument();
+  });
+
+  describe('getAcquisitionMethodValue', () => {
+    it('should return \'null\' if PO Line \'acquisitionMethod\' is undefined or null', () => {
+      const acqMethodValue = getAcquisitionMethodValue(null, null);
+
+      expect(acqMethodValue).toBeNull();
+    });
+
+    it('should return \'invalid reference\' label if acq method with specified ID was not loaded', () => {
+      const acqMethodValue = getAcquisitionMethodValue('testAcqMethod', null);
+
+      expect(acqMethodValue).toEqual(<FormattedMessage id="ui-orders.acquisitionMethod.invalid" />);
+    });
+
+    it('should return translated label for acq method', () => {
+      const acqMethodValue = getAcquisitionMethodValue('acqMethod', { value: ACQUISITION_METHOD.approvalPlan });
+
+      expect(acqMethodValue).toEqual(
+        <FormattedMessage
+          id="stripes-acq-components.acquisition_method.approvalPlan"
+          defaultMessage={ACQUISITION_METHOD.approvalPlan}
+        />,
+      );
+    });
+  });
+
+  describe('getReceivingWorkflowValue', () => {
+    it('should return \'null\' if PO Line \'checkinItems\' is undefined or null', () => {
+      const acqMethodValue = getReceivingWorkflowValue(null);
+
+      expect(acqMethodValue).toBeNull();
+    });
+
+    it('should return translated label for receiving workflow', () => {
+      expect(getReceivingWorkflowValue(false)).toEqual(<FormattedMessage id="ui-orders.poLine.receivingWorkflow.synchronized" />);
+      expect(getReceivingWorkflowValue(true)).toEqual(<FormattedMessage id="ui-orders.poLine.receivingWorkflow.independent" />);
+    });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-1103
## Approach
- exclude getting a single acquisition method from the `useAcqMethods` hook in `useAcqMethod` to keep single responsibility;
- check if the PO Line `acquisitionMethod` and `checkinItems` values are defined for displaying them in the `Acquisition method` and `Receiving workflow` fields respectively.

<details><summary>Empty fields</summary>
<p>

![chrome_V5AX2iG6X2](https://github.com/folio-org/ui-orders/assets/88109087/95c111e8-f02c-4a95-ad34-df8087ed90b6)

</p>
</details>

<details><summary>Populated fields</summary>
<p>

![chrome_UchrrTl7ez](https://github.com/folio-org/ui-orders/assets/88109087/5c7e43a6-c37e-448b-924a-15407eebad58)

</p>
</details>

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
