### PR TITLE
ERM-2641: Upgrade to Grails 5 (including Hibernate 5.6.x) for Poppy

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "configuration": "2.0",
       "contributor-name-types": "1.2",
       "contributor-types": "2.0",
-      "erm": "4.0 5.0",
+      "erm": "4.0 5.0 6.0",
       "finance.budgets": "1.3 2.0",
       "finance.exchange-rate": "1.0",
       "finance.expense-classes": "2.0 3.0",


### PR DESCRIPTION
build: erm 6.0

Added okapi interface dependency on new erm interface 6.0

refs ERM-2641
