### PR TITLE
UIOR-1169 Populate values from a template after the fields are regist…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add missed permission to fetch org types in view only mode. Refs UIOR-1168.
 * Preview contains blank page when trying to print an order. Refs UIOR-1173.
 * Do not disable account numbers having only one account available. Refs UIOR-1174.
+* Populate values from a template after the fields are registered. Refs UIOR-1169.
 
 ## [5.0.0](https://github.com/folio-org/ui-orders/tree/v5.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v4.0.3...v5.0.0)

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -74,9 +74,10 @@ import styles from './POLineForm.css';
 import { createPOLDataFromInstance } from './Item/util';
 
 const GAME_CHANGER_FIELDS = ['isPackage', 'orderFormat', 'checkinItems', 'packagePoLineId', 'instanceId'];
+const CHANGER_TIMEOUT = 20;
 
 function POLineForm({
-  form: { change, batch },
+  form: { change, batch, getRegisteredFields },
   form,
   initialValues,
   onCancel,
@@ -105,12 +106,14 @@ function POLineForm({
 
   const identifierTypes = getIdentifierTypesForSelect(parentResources);
   const locations = parentResources?.locations?.records;
-  const templateValue = getOrderTemplateValue(parentResources, order?.template, {
-    locations,
-  });
   const lineId = get(initialValues, 'id');
   const saveBtnLabelId = isCreateAnotherChecked ? 'save' : 'saveAndClose';
-  const initialTemplateInventoryData = (
+
+  const templateValue = useMemo(() => getOrderTemplateValue(parentResources, order?.template, {
+    locations,
+  }), [locations, order?.template, parentResources]);
+
+  const initialTemplateInventoryData = useMemo(() => (
     !lineId && templateValue.id
       ? {
         ...pick(templateValue, [
@@ -124,35 +127,40 @@ function POLineForm({
         ]),
       }
       : {}
-  );
-  const initialInventoryData = isCreateFromInstance
-    ? createPOLDataFromInstance(instance, identifierTypes)
-    : initialTemplateInventoryData;
+  ), [lineId, templateValue]);
+
+  const initialInventoryData = useMemo(() => (
+    isCreateFromInstance
+      ? createPOLDataFromInstance(instance, identifierTypes)
+      : initialTemplateInventoryData
+  ), [identifierTypes, initialTemplateInventoryData, instance, isCreateFromInstance]);
+
+  /*
+    Populate field values for new PO Line from a template if it exist.
+    First, the values of the fields are set, which, when changed, change other fields.
+  */  
+  useEffect(() => {
+    if (!lineId && templateValue.id) {
+      const populateFieldsFromTemplate = (fields) => {
+        batch(() => {
+          fields.forEach(field => {
+            const templateField = POL_TEMPLATE_FIELDS_MAP[field] || field;
+            const templateFieldValue = get(templateValue, templateField);
+
+            if (templateFieldValue !== undefined) change(field, templateFieldValue);
+          });
+        });
+      };
+
+      setTimeout(() => populateFieldsFromTemplate(GAME_CHANGER_FIELDS));
+      setTimeout(() => populateFieldsFromTemplate(getRegisteredFields()), CHANGER_TIMEOUT);
+    }
+  }, [batch, change, getRegisteredFields, lineId, templateValue]);
 
   useEffect(() => {
-    setTimeout(() => {
-      if (!lineId && templateValue.id) {
-        form.batch(() => {
-          GAME_CHANGER_FIELDS.forEach(field => {
-            const templateField = POL_TEMPLATE_FIELDS_MAP[field] || field;
-            const templateFieldValue = get(templateValue, templateField);
-
-            if (templateFieldValue !== undefined) change(field, templateFieldValue);
-          });
-        });
-
-        form.batch(() => {
-          form.getRegisteredFields().forEach(field => {
-            const templateField = POL_TEMPLATE_FIELDS_MAP[field] || field;
-            const templateFieldValue = get(templateValue, templateField);
-
-            if (templateFieldValue !== undefined) change(field, templateFieldValue);
-          });
-        });
-      }
-
-      if (isCreateFromInstance) {
-        form.batch(() => {
+    if (isCreateFromInstance) {
+      setTimeout(() => {
+        batch(() => {
           change('isPackage', false);
 
           Object.keys(initialInventoryData).forEach(field => {
@@ -161,12 +169,13 @@ function POLineForm({
             } else change(field, initialInventoryData[field]);
           });
         });
-      }
-    });
+      }, CHANGER_TIMEOUT);
+    }
+  }, [batch, change, initialInventoryData, isCreateFromInstance]);
 
+  useEffect(() => {
     setHiddenFields(templateValue?.hiddenFields || {});
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [change, instance?.id, isCreateFromInstance, lineId, templateValue.id]);
+  }, [templateValue?.hiddenFields]);
 
   const getAddFirstMenu = () => {
     return (

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -74,7 +74,7 @@ import styles from './POLineForm.css';
 import { createPOLDataFromInstance } from './Item/util';
 
 const GAME_CHANGER_FIELDS = ['isPackage', 'orderFormat', 'checkinItems', 'packagePoLineId', 'instanceId'];
-const CHANGER_TIMEOUT = 20;
+const GAME_CHANGER_TIMEOUT = 20;
 
 function POLineForm({
   form: { change, batch, getRegisteredFields },
@@ -138,7 +138,7 @@ function POLineForm({
   /*
     Populate field values for new PO Line from a template if it exist.
     First, the values of the fields are set, which, when changed, change other fields.
-  */  
+  */
   useEffect(() => {
     if (!lineId && templateValue.id) {
       const populateFieldsFromTemplate = (fields) => {
@@ -153,7 +153,7 @@ function POLineForm({
       };
 
       setTimeout(() => populateFieldsFromTemplate(GAME_CHANGER_FIELDS));
-      setTimeout(() => populateFieldsFromTemplate(getRegisteredFields()), CHANGER_TIMEOUT);
+      setTimeout(() => populateFieldsFromTemplate(getRegisteredFields()), GAME_CHANGER_TIMEOUT);
     }
   }, [batch, change, getRegisteredFields, lineId, templateValue]);
 
@@ -169,7 +169,7 @@ function POLineForm({
             } else change(field, initialInventoryData[field]);
           });
         });
-      }, CHANGER_TIMEOUT);
+      }, GAME_CHANGER_TIMEOUT);
     }
   }, [batch, change, initialInventoryData, isCreateFromInstance]);
 


### PR DESCRIPTION
…ered

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-1169

Pre-filling fields from the template stopped working in the PO Line form.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Split logic from `useEffect` into separate hooks to reduce cognitive complexity and applying single responsibility principle;
- Wrap initial batch changes in `setTimeout` to move them to the separate macrotasks and give time to set "game changer" fields.
- 
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/989a7d10-5905-4708-bf57-41522a1166da


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
