### PR TITLE
UIOR-1078: enable subscription to filed when workflow status is open

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
           "orders.po-lines.collection.get",
           "orders.po-lines.item.get",
           "orders.titles.collection.get",
+          "organizations.organizations.collection.get",
           "organizations-storage.organization-types.collection.get",
           "ui-orders.third-party-services"
         ]

--- a/src/components/POLine/Item/ItemForm.js
+++ b/src/components/POLine/Item/ItemForm.js
@@ -36,11 +36,13 @@ import {
   getNormalizedInventoryData,
   shouldSetInstanceId,
 } from './util';
-import { isWorkflowStatusIsPending } from '../../PurchaseOrder/util';
+import {
+  isWorkflowStatusIsPending,
+  isWorkflowStatusOpen,
+} from '../../PurchaseOrder/util';
 import PackagePoLineField from './PackagePoLineField';
 import { BreakInstanceConnectionModal } from './BreakInstanceConnectionModal';
 import { TitleField } from './TitleField';
-// import { SubscriptionIntervalField } from './SubscriptionIntervalField';
 import css from './ItemForm.css';
 
 const FIELDS_TO_INTERCEPT_ON_DELETE = ['contributors'];
@@ -277,6 +279,7 @@ class ItemForm extends Component {
 
   render() {
     const isPostPendingOrder = !isWorkflowStatusIsPending(this.props.order);
+    const isOrderOpen = isWorkflowStatusOpen(this.props.order);
     const {
       contributorNameTypes,
       formValues,
@@ -380,7 +383,7 @@ class ItemForm extends Component {
                 <FieldDatepickerFinal
                   label={<FormattedMessage id="ui-orders.itemDetails.subscriptionTo" />}
                   name="details.subscriptionTo"
-                  isNonInteractive={isPostPendingOrder}
+                  isNonInteractive={isPostPendingOrder && !isOrderOpen}
                   validateFields={[]}
                 />
               </VisibilityControl>

--- a/src/components/POLine/Item/ItemForm.test.js
+++ b/src/components/POLine/Item/ItemForm.test.js
@@ -172,6 +172,18 @@ describe('ItemForm', () => {
     expect(screen.getByText('ui-orders.itemDetails.connectedTitle')).toBeInTheDocument();
   });
 
+  it('should `Subscription to` filed to be enabled when order status is `Open`', async () => {
+    renderItemForm({ order: { ...order, workflowStatus: 'Open' } });
+
+    expect(screen.getByLabelText('ui-orders.itemDetails.subscriptionTo')).toBeEnabled();
+  });
+
+  it('should `Subscription to` filed to be disabled when order status is `Closed`', async () => {
+    renderItemForm({ order: { ...order, workflowStatus: 'Closed' } });
+
+    expect(screen.queryByLabelText('ui-orders.itemDetails.subscriptionTo')).toBeNull();
+  });
+
   describe('Connected instance', () => {
     beforeEach(async () => {
       renderItemForm({


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UIOR-1078](https://issues.folio.org/browse/UIOR-1078) - enable subscription to filed when workflow status is `open`
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

https://github.com/folio-org/ui-orders/assets/116072773/c14098e2-9afd-4d58-8ab0-047766fa0034

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
