### PR TITLE
UIOR-396 UIOR-397 Add 'claiming active' and 'claiming interval' fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Disable donor field in POL. Refs UIOR-1149.
 * Populate donor info from fund into POL. Refs UIOR-1148.
 * Add donor info to Order facets. Refs UIOR-1150.
+* Populate claiming interval in POL from Organization record. Refs UIOR-396.
+* Add claiming checkbox to POL details. Refs UIOR-397.
 
 ## [5.0.1](https://github.com/folio-org/ui-orders/tree/v5.0.1) (2023-11-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v5.0.0...v5.0.1)

--- a/src/common/POLFields/DetailsFields/FieldClaimingActive.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingActive.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import { Field } from 'react-final-form';
+import { FormattedMessage } from 'react-intl';
+
+import { Checkbox } from '@folio/stripes/components';
+
+export const FieldClaimingActive = ({ onChange }) => {
+  return (
+    <Field
+      component={Checkbox}
+      fullWidth
+      label={<FormattedMessage id="ui-orders.poLine.claimingActive" />}
+      onChange={onChange}
+      name="claimingActive"
+      type="checkbox"
+      vertical
+      validateFields={[]}
+    />
+  );
+};
+
+FieldClaimingActive.propTypes = {
+  onChange: PropTypes.func,
+};

--- a/src/common/POLFields/DetailsFields/FieldClaimingActive.test.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingActive.test.js
@@ -4,7 +4,7 @@ import { render, screen } from '@folio/jest-config-stripes/testing-library/react
 
 import { FieldClaimingActive } from './FieldClaimingActive';
 
-const renderFieldCheckInItems = (props = {}) => render(
+const renderFieldClaimingActive = (props = {}) => render(
   <Form
     onSubmit={() => jest.fn()}
     render={() => (
@@ -17,7 +17,7 @@ const renderFieldCheckInItems = (props = {}) => render(
 
 describe('FieldClaimingActive', () => {
   it('should render \'Claiming active\' field', () => {
-    renderFieldCheckInItems();
+    renderFieldClaimingActive();
 
     expect(screen.getByText('ui-orders.poLine.claimingActive')).toBeInTheDocument();
   });

--- a/src/common/POLFields/DetailsFields/FieldClaimingActive.test.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingActive.test.js
@@ -1,0 +1,24 @@
+import { Form } from 'react-final-form';
+
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import { FieldClaimingActive } from './FieldClaimingActive';
+
+const renderFieldCheckInItems = (props = {}) => render(
+  <Form
+    onSubmit={() => jest.fn()}
+    render={() => (
+      <FieldClaimingActive
+        {...props}
+      />
+    )}
+  />,
+);
+
+describe('FieldClaimingActive', () => {
+  it('should render \'Claiming active\' field', () => {
+    renderFieldCheckInItems();
+
+    expect(screen.getByText('ui-orders.poLine.claimingActive')).toBeInTheDocument();
+  });
+});

--- a/src/common/POLFields/DetailsFields/FieldClaimingInterval.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingInterval.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import { Field } from 'react-final-form';
+import { FormattedMessage } from 'react-intl';
+
+import { TextField } from '@folio/stripes/components';
+
+export const FieldClaimingInterval = ({ disabled }) => {
+  return (
+    <Field
+      label={<FormattedMessage id="ui-orders.poLine.claimingInterval" />}
+      name="claimingInterval"
+      component={TextField}
+      type="number"
+      fullWidth
+      disabled={disabled}
+      validateFields={[]}
+    />
+  );
+};
+
+FieldClaimingInterval.propTypes = {
+  disabled: PropTypes.bool,
+};

--- a/src/common/POLFields/DetailsFields/FieldClaimingInterval.test.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingInterval.test.js
@@ -4,7 +4,7 @@ import { render, screen } from '@folio/jest-config-stripes/testing-library/react
 
 import { FieldClaimingInterval } from './FieldClaimingInterval';
 
-const FieldClaimingInterval = (props = {}) => render(
+const renderFieldClaimingInterval = (props = {}) => render(
   <Form
     onSubmit={() => jest.fn()}
     render={() => (
@@ -17,7 +17,7 @@ const FieldClaimingInterval = (props = {}) => render(
 
 describe('FieldClaimingInterval', () => {
   it('should render \'Claiming interval\' field', () => {
-    renderFieldCheckInItems();
+    renderFieldClaimingInterval();
 
     expect(screen.getByText('ui-orders.poLine.claimingInterval')).toBeInTheDocument();
   });

--- a/src/common/POLFields/DetailsFields/FieldClaimingInterval.test.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingInterval.test.js
@@ -1,0 +1,24 @@
+import { Form } from 'react-final-form';
+
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import { FieldClaimingInterval } from './FieldClaimingInterval';
+
+const FieldClaimingInterval = (props = {}) => render(
+  <Form
+    onSubmit={() => jest.fn()}
+    render={() => (
+      <FieldClaimingInterval
+        {...props}
+      />
+    )}
+  />,
+);
+
+describe('FieldClaimingInterval', () => {
+  it('should render \'Claiming interval\' field', () => {
+    renderFieldCheckInItems();
+
+    expect(screen.getByText('ui-orders.poLine.claimingInterval')).toBeInTheDocument();
+  });
+});

--- a/src/common/POLFields/index.js
+++ b/src/common/POLFields/index.js
@@ -2,6 +2,8 @@ export { default as FieldsLocation } from './FieldsLocation';
 export { default as FieldMaterialType } from './FieldMaterialType';
 
 // details
+export { FieldClaimingActive } from './DetailsFields/FieldClaimingActive';
+export { FieldClaimingInterval } from './DetailsFields/FieldClaimingInterval';
 export { default as FieldPOLineNumber } from './DetailsFields/FieldPOLineNumber';
 export { default as FieldAcquisitionMethod } from './DetailsFields/FieldAcquisitionMethod';
 export { default as FieldOrderFormat } from './DetailsFields/FieldOrderFormat';

--- a/src/components/LayerCollection/LayerPOLine.js
+++ b/src/components/LayerCollection/LayerPOLine.js
@@ -458,6 +458,8 @@ function LayerPOLine({
   const getCreatePOLIneInitialValues = useMemo(() => {
     const orderId = order?.id;
     const newObj = {
+      claimingActive: false,
+      claimingInterval: vendor?.claimingInterval,
       source: sourceValues.user,
       cost: {
         currency: stripes.currency,

--- a/src/components/POLine/POLineDetails/POLineDetails.js
+++ b/src/components/POLine/POLineDetails/POLineDetails.js
@@ -210,7 +210,7 @@ const POLineDetails = ({ line, hiddenFields }) => {
           </Col>
         </IfVisible>
       </Row>
-      
+
       <Row start="xs">
         <IfVisible visible={!hiddenFields.claimingActive}>
           <Col

--- a/src/components/POLine/POLineDetails/POLineDetails.js
+++ b/src/components/POLine/POLineDetails/POLineDetails.js
@@ -210,6 +210,35 @@ const POLineDetails = ({ line, hiddenFields }) => {
           </Col>
         </IfVisible>
       </Row>
+      
+      <Row start="xs">
+        <IfVisible visible={!hiddenFields.claimingActive}>
+          <Col
+            xs={6}
+            lg={3}
+          >
+            <Checkbox
+              checked={line?.claimingActive}
+              disabled
+              label={<FormattedMessage id="ui-orders.poLine.claimingActive" />}
+              vertical
+            />
+          </Col>
+        </IfVisible>
+
+        <IfVisible visible={!hiddenFields.claimingInterval}>
+          <Col
+            xs={6}
+            lg={3}
+          >
+            <KeyValue
+              label={<FormattedMessage id="ui-orders.poLine.claimingInterval" />}
+              value={line?.claimingInterval}
+            />
+          </Col>
+        </IfVisible>
+      </Row>
+
       <Row start="xs">
         <IfVisible visible={!hiddenFields.cancellationRestriction}>
           <Col

--- a/src/components/POLine/POLineDetails/POLineDetails.test.js
+++ b/src/components/POLine/POLineDetails/POLineDetails.test.js
@@ -42,6 +42,8 @@ describe('POLineDetails', () => {
     expect(screen.getByText('ui-orders.poLine.requester')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.cancellationRestriction')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.rush')).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.poLine.claimingActive')).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.poLine.claimingInterval')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.сollection')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.receivingWorkflow')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.cancellationRestrictionNote')).toBeInTheDocument();

--- a/src/components/POLine/POLineDetails/POLineDetailsForm.js
+++ b/src/components/POLine/POLineDetails/POLineDetailsForm.js
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
+import { useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { get } from 'lodash';
 
 import {
   Col,
@@ -32,6 +32,8 @@ import {
   FieldRequester,
   FieldCancellationRestrictionNote,
   FieldPOLineDescription,
+  FieldClaimingActive,
+  FieldClaimingInterval,
 } from '../../../common/POLFields';
 import { IfFieldVisible } from '../../../common/IfFieldVisible';
 import getCreateInventorySetting from '../../../common/utils/getCreateInventorySetting';
@@ -55,6 +57,8 @@ function POLineDetailsForm({
   const isPostPendingOrder = !isWorkflowStatusIsPending(order);
   const isPackage = get(formValues, 'isPackage');
 
+  const isClaimingActive = Boolean(formValues?.claimingActive);
+
   const checkinItemsFieldDisabled = (
     isPostPendingOrder
     || isPackage
@@ -77,6 +81,14 @@ function POLineDetailsForm({
       change('checkinItems', true);
     }
   }, [change, isPostPendingOrder]);
+
+  const onClaimingActiveChange = useCallback((event) => {
+    const { target: { checked } } = event;
+
+    change('claimingActive', checked);
+
+    if (!checked) change('claimingInterval', undefined);
+  }, [change]);
 
   return (
     <>
@@ -202,6 +214,27 @@ function POLineDetailsForm({
           </Col>
         </IfFieldVisible>
       </Row>
+
+      <Row>
+        <IfFieldVisible visible={!hiddenFields.claimingActive} name="claimingActive">
+          <Col
+            xs={6}
+            md={3}
+          >
+            <FieldClaimingActive onChange={onClaimingActiveChange} />
+          </Col>
+        </IfFieldVisible>
+
+        <IfFieldVisible visible={!hiddenFields.claimingInterval} name="claimingInterval">
+          <Col
+            xs={6}
+            md={3}
+          >
+            <FieldClaimingInterval disabled={!isClaimingActive} />
+          </Col>
+        </IfFieldVisible>
+      </Row>
+
       <Row>
         <IfFieldVisible visible={!hiddenFields.cancellationRestriction} name="cancellationRestriction">
           <Col

--- a/src/components/POLine/POLineDetails/POLineDetailsForm.test.js
+++ b/src/components/POLine/POLineDetails/POLineDetailsForm.test.js
@@ -67,6 +67,8 @@ describe('POLineDetailsForm', () => {
     expect(screen.getByText('ui-orders.poLine.donor')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.selector')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.requester')).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.poLine.claimingActive')).toBeInTheDocument();
+    expect(screen.getByText('ui-orders.poLine.claimingInterval')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.cancellationRestriction')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.rush')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.poLine.сollection')).toBeInTheDocument();
@@ -87,5 +89,23 @@ describe('POLineDetailsForm', () => {
 
     expect(receivingWorkflowField).toHaveValue('true');
     expect(receivingWorkflowField).toBeDisabled();
+  });
+
+  it('should clear the \'Claiming interval\' field when a user unchecked \'Claiming active\' checkbox', async () => {
+    renderPOLineDetailsForm(null, { claimingActive: false });
+
+    const claimingActiveField = screen.getByRole('checkbox', { name: 'ui-orders.poLine.claimingActive' });
+    const claimingIntervalField = screen.getByLabelText('ui-orders.poLine.claimingInterval');
+
+    await userEvent.click(claimingActiveField);
+    await userEvent.type(claimingIntervalField, '42');
+
+    expect(claimingActiveField).toBeChecked();
+    expect(claimingIntervalField).toHaveValue(42);
+
+    await userEvent.click(claimingActiveField);
+
+    expect(claimingActiveField).not.toBeChecked();
+    expect(claimingIntervalField).toHaveValue(null);
   });
 });

--- a/translations/ui-orders/en.json
+++ b/translations/ui-orders/en.json
@@ -510,6 +510,8 @@
   "poLine.automaticExport": "Automatic export",
   "poLine.cancellationRestriction": "Cancellation restriction",
   "poLine.cancellationRestrictionNote": "Cancellation description",
+  "poLine.claimingActive": "Claiming active",
+  "poLine.claimingInterval": "Claiming interval",
   "poLine.receivingWorkflow": "Receiving workflow",
   "poLine.receivingWorkflow.info": "Selecting synchronized will keep the order quantity and the number of pieces to be received, in sync. This also means updating one will update the other. When the order is opened, the system will generate pieces based on the quantity order.",
   "poLine.receivingWorkflow.independent": "Independent order and receipt quantity",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-396
https://issues.folio.org/browse/UIOR-397

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Implement new components for viewing and editing the "Claiming active" and "Claiming interval" fields in PO Line details.
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/a75c54e9-0581-41c4-a1d2-4325413f67d7

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
