### PR TITLE
UIOR-1181 Optimize linked instances query to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add donor info to Order facets. Refs UIOR-1150.
 * Populate claiming interval in POL from Organization record. Refs UIOR-396.
 * Add claiming checkbox to POL details. Refs UIOR-397.
-* Optimize linked instances query to improve performance. Refs UIOR-UIOR-1181.
+* Optimize linked instances query to improve performance. Refs UIOR-1181.
 
 ## [5.0.1](https://github.com/folio-org/ui-orders/tree/v5.0.1) (2023-11-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v5.0.0...v5.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add donor info to Order facets. Refs UIOR-1150.
 * Populate claiming interval in POL from Organization record. Refs UIOR-396.
 * Add claiming checkbox to POL details. Refs UIOR-397.
+* Optimize linked instances query to improve performance. Refs UIOR-UIOR-1181.
 
 ## [5.0.1](https://github.com/folio-org/ui-orders/tree/v5.0.1) (2023-11-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v5.0.0...v5.0.1)

--- a/src/components/POLine/LineLinkedInstances/hooks/useLinkedInstances/useLinkedInstances.js
+++ b/src/components/POLine/LineLinkedInstances/hooks/useLinkedInstances/useLinkedInstances.js
@@ -53,7 +53,7 @@ export const useLinkedTitles = line => {
     () => {
       const searchParams = {
         limit: LIMIT_MAX,
-        query: `poLineId=${line.id} and instanceId="" sortby title`,
+        query: `poLineId=${line.id} sortby title`,
       };
 
       return ky.get('orders/titles', { searchParams }).json();

--- a/src/components/POLine/LineLinkedInstances/hooks/useLinkedInstances/useLinkedInstances.js
+++ b/src/components/POLine/LineLinkedInstances/hooks/useLinkedInstances/useLinkedInstances.js
@@ -53,7 +53,7 @@ export const useLinkedTitles = line => {
     () => {
       const searchParams = {
         limit: LIMIT_MAX,
-        query: `poLineId=${line.id} sortby title`,
+        query: `poLineId==${line.id} sortby title`,
       };
 
       return ky.get('orders/titles', { searchParams }).json();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-1181

Some queries triggered by UI do not use DB indexes during Get Order/Get Po Line/ Open Oder/ Receive order flow. Need to optimize them to improve performance.

```
14:20:12 [352325/orders;830317/orders-storage] [diku] [c88a8880-f8ec-55c5-a808-14cfb0744108] [mod_orders_storage] WARN  CQL2PgJSON           Doing FT search without index for titles.jsonb->>'instanceId', CQL >>> SQL: instanceId = "" >>> titles.jsonb->>'instanceId' ~ '' 
```

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Delete redundant `instanceId=""`.
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
