### PR TITLE
UIOR-1192 Add validation for the 'claimingInterval' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Optimize linked instances query to improve performance. Refs UIOR-1181.
 * Add permission to fetch invoices-related fiscal years into the orders "view" permission set. UIOR-1185.
 * Do not show special fields in "Version history" for PO and POL. Refs UIOR-1117.
+* Add validation for the `claimingInterval` field. Refs UIOR-1192.
 
 ## [5.0.1](https://github.com/folio-org/ui-orders/tree/v5.0.1) (2023-11-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v5.0.0...v5.0.1)

--- a/src/common/POLFields/DetailsFields/FieldClaimingActive.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingActive.js
@@ -14,7 +14,7 @@ export const FieldClaimingActive = ({ onChange }) => {
       name="claimingActive"
       type="checkbox"
       vertical
-      validateFields={[]}
+      validateFields={['claimingInterval']}
     />
   );
 };

--- a/src/common/POLFields/DetailsFields/FieldClaimingInterval.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingInterval.js
@@ -3,21 +3,38 @@ import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
 import { TextField } from '@folio/stripes/components';
+import {
+  validateRequired,
+  validateRequiredPositiveNumber,
+} from '@folio/stripes-acq-components';
 
-export const FieldClaimingInterval = ({ disabled }) => {
+const validate = (value) => {
+  return validateRequired(value) || validateRequiredPositiveNumber(value);
+};
+
+export const FieldClaimingInterval = ({ disabled, required }) => {
   return (
     <Field
       label={<FormattedMessage id="ui-orders.poLine.claimingInterval" />}
       name="claimingInterval"
       component={TextField}
       type="number"
+      min={1}
       fullWidth
       disabled={disabled}
+      required={required}
+      validate={required ? validate : undefined}
       validateFields={[]}
     />
   );
 };
 
+FieldClaimingInterval.defaultProps = {
+  disabled: false,
+  required: false,
+};
+
 FieldClaimingInterval.propTypes = {
   disabled: PropTypes.bool,
+  required: PropTypes.bool,
 };

--- a/src/common/POLFields/DetailsFields/FieldClaimingInterval.js
+++ b/src/common/POLFields/DetailsFields/FieldClaimingInterval.js
@@ -8,7 +8,9 @@ import {
   validateRequiredPositiveNumber,
 } from '@folio/stripes-acq-components';
 
-const validate = (value) => {
+const validate = (value, { claimingActive }) => {
+  if (!claimingActive) return undefined;
+
   return validateRequired(value) || validateRequiredPositiveNumber(value);
 };
 
@@ -23,7 +25,7 @@ export const FieldClaimingInterval = ({ disabled, required }) => {
       fullWidth
       disabled={disabled}
       required={required}
-      validate={required ? validate : undefined}
+      validate={validate}
       validateFields={[]}
     />
   );

--- a/src/components/POLine/POLineDetails/POLineDetailsForm.js
+++ b/src/components/POLine/POLineDetails/POLineDetailsForm.js
@@ -230,7 +230,10 @@ function POLineDetailsForm({
             xs={6}
             md={3}
           >
-            <FieldClaimingInterval disabled={!isClaimingActive} />
+            <FieldClaimingInterval
+              disabled={!isClaimingActive}
+              required={isClaimingActive}
+            />
           </Col>
         </IfFieldVisible>
       </Row>

--- a/src/components/POLine/POLineDetails/POLineDetailsForm.test.js
+++ b/src/components/POLine/POLineDetails/POLineDetailsForm.test.js
@@ -108,4 +108,32 @@ describe('POLineDetailsForm', () => {
     expect(claimingActiveField).not.toBeChecked();
     expect(claimingIntervalField).toHaveValue(null);
   });
+
+  it('should validate \'Claiming interval\' field', async () => {
+    renderPOLineDetailsForm(null, { claimingActive: false });
+
+    const claimingActiveField = screen.getByRole('checkbox', { name: 'ui-orders.poLine.claimingActive' });
+    const claimingIntervalField = screen.getByLabelText('ui-orders.poLine.claimingInterval');
+
+    // Shouldn't be required if claimeng active equals "false"
+    expect(claimingIntervalField).not.toBeRequired();
+
+    await userEvent.click(claimingActiveField);
+    expect(claimingIntervalField).toBeRequired();
+    expect(claimingIntervalField).not.toBeValid();
+
+    await userEvent.type(claimingIntervalField, '-1');
+    expect(claimingIntervalField).toHaveValue(-1);
+    expect(claimingIntervalField).not.toBeValid();
+
+    await userEvent.clear(claimingIntervalField);
+    await userEvent.type(claimingIntervalField, '0');
+    expect(claimingIntervalField).toHaveValue(0);
+    expect(claimingIntervalField).not.toBeValid();
+
+    await userEvent.clear(claimingIntervalField);
+    await userEvent.type(claimingIntervalField, '42');
+    expect(claimingIntervalField).toHaveValue(42);
+    expect(claimingIntervalField).toBeValid();
+  });
 });

--- a/src/components/POLine/POLineDetails/POLineDetailsForm.test.js
+++ b/src/components/POLine/POLineDetails/POLineDetailsForm.test.js
@@ -115,8 +115,9 @@ describe('POLineDetailsForm', () => {
     const claimingActiveField = screen.getByRole('checkbox', { name: 'ui-orders.poLine.claimingActive' });
     const claimingIntervalField = screen.getByLabelText('ui-orders.poLine.claimingInterval');
 
-    // Shouldn't be required if claimeng active equals "false"
+    // Shouldn't be required if "Claiming active" unchecked
     expect(claimingIntervalField).not.toBeRequired();
+    expect(claimingIntervalField).toBeValid();
 
     await userEvent.click(claimingActiveField);
     expect(claimingIntervalField).toBeRequired();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIOR-1192

Claiming interval should be a required field when claiming is active for PO Line.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Apply validation for claiming interval field when it's required field (claiming active).

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/680491f0-ba53-4b0c-bd56-705bd3051616


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
