### PR TITLE
UIOR-1225 Wait for custom fields to render before populating form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Bump up okapi interfaces for `pieces` (2.0 3.0). Refs UIOR-1212.
 * Invoice line Subscription fields are not populated correctly. Refs UIOR-1220.
 * Add missing permissions for custom fields. Refs UIOR-1223.
+* Wait for custom fields to render before populating form fields. Refs UIOR-1225.
 
 ## [5.0.1](https://github.com/folio-org/ui-orders/tree/v5.0.1) (2023-11-08)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v5.0.0...v5.0.1)

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -184,7 +184,7 @@ function POLineForm({
   ), [identifierTypes, initialTemplateInventoryData, instance, isCreateFromInstance]);
 
   /*
-    Populate field values for new PO Line from a template if it exist.
+    Populate field values for new PO Line from a template if it exist and custom fields are loaded.
     First, the values of the fields are set, which, when changed, change other fields.
   */
 

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -121,6 +121,7 @@ function POLineForm({
 }) {
   const history = useHistory();
   const [hiddenFields, setHiddenFields] = useState({});
+  const [isCustomFieldsLoaded, setIsCustomFieldsLoaded] = useState(false);
   const { validateFundDistributionTotal } = useFundDistributionValidation(formValues);
 
   const accordionStatusRef = useRef();
@@ -188,7 +189,7 @@ function POLineForm({
   */
 
   useEffect(() => {
-    if (!lineId && templateValue.id) {
+    if (!lineId && templateValue.id && isCustomFieldsLoaded) {
       const populateFieldsFromTemplate = (fields) => {
         batch(() => {
           fields.forEach(field => {
@@ -203,7 +204,7 @@ function POLineForm({
       setTimeout(() => populateFieldsFromTemplate(GAME_CHANGER_FIELDS));
       setTimeout(() => populateFieldsFromTemplate(getRegisteredFields()), GAME_CHANGER_TIMEOUT);
     }
-  }, [batch, change, getRegisteredFields, lineId, templateValue]);
+  }, [batch, change, getRegisteredFields, lineId, templateValue, isCustomFieldsLoaded]);
 
   useEffect(() => {
     if (isCreateFromInstance) {
@@ -363,6 +364,10 @@ function POLineForm({
     if (holdingFieldName) {
       change(holdingFieldName, holdingId);
     }
+  };
+
+  const handleCustomFieldsLoaded = () => {
+    setIsCustomFieldsLoaded(true);
   };
 
   const shortcuts = [
@@ -615,6 +620,7 @@ function POLineForm({
                           entityType="po_line"
                           fieldComponent={Field}
                           finalFormCustomFieldsValues={customFieldsValues}
+                          onComponentLoad={handleCustomFieldsLoaded}
                         />
                       </AccordionSet>
                     </Col>

--- a/src/components/POLine/POLineForm.test.js
+++ b/src/components/POLine/POLineForm.test.js
@@ -30,7 +30,11 @@ jest.mock('@folio/stripes/components', () => ({
 }));
 jest.mock('@folio/stripes/smart-components', () => ({
   ...jest.requireActual('@folio/stripes/smart-components'),
-  EditCustomFieldsRecord: jest.fn().mockReturnValue('EditCustomFieldsRecord'),
+  EditCustomFieldsRecord: jest.fn(props => {
+    props.onComponentLoad();
+
+    return 'EditCustomFieldsRecord';
+  }),
 }));
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Fixes [UIOR-1225](https://folio-org.atlassian.net/browse/UIOR-1225).

This pull request resolves an issue with the asynchronous rendering of form field elements within `<EditCustomFieldsRecord>`. Before populating the form fields with template values, it is crucial to ensure that these elements have completed rendering.

## Approach
- Utilized the `onComponentLoad` prop of `<EditCustomFieldsRecord>` to ascertain if custom fields have loaded.
- Refactored `useEffect` methods to address the excessive nesting of functions, as detected by sonar.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.