### PR TITLE
UIOR-1202 UX Consistency: HTML page title display when third pane (detail record) displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for ui-orders
 
-## (6.1.0 IN PROGRESS)
+## 6.1.0 (IN PROGRESS)
+
+* UX Consistency: HTML page title display when third pane (detail record) displays. Refs UIOR-1202.
 
 ## [6.0.0](https://github.com/folio-org/ui-orders/tree/v6.0.0) (2024-03-19)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v5.0.2...v6.0.0)

--- a/src/components/POLine/POLineVersionView/POLineVersionView.js
+++ b/src/components/POLine/POLineVersionView/POLineVersionView.js
@@ -7,6 +7,7 @@ import {
   IconButton,
   PaneMenu,
 } from '@folio/stripes/components';
+import { TitleManager } from '@folio/stripes/core';
 import {
   VersionHistoryPane,
   VersionViewContextProvider,
@@ -90,6 +91,7 @@ const POLineVersionView = ({
       versions={versions}
       versionId={versionId}
     >
+      <TitleManager record={orderLine?.poLineNumber} />
       <VersionView
         id="order-line"
         isLoading={isVersionLoading}

--- a/src/components/POLine/POLineView.js
+++ b/src/components/POLine/POLineView.js
@@ -7,6 +7,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 
 import {
   IfPermission,
+  TitleManager,
   useStripes,
 } from '@folio/stripes/core';
 import {
@@ -325,6 +326,7 @@ const POLineView = ({
       isWithinScope={checkScope}
       scope={document.body}
     >
+      <TitleManager record={poLineNumber} />
       <Pane
         id="order-lines-details"
         defaultWidth="fill"

--- a/src/components/PurchaseOrder/PO.js
+++ b/src/components/PurchaseOrder/PO.js
@@ -7,6 +7,7 @@ import { get } from 'lodash';
 
 import {
   IfPermission,
+  TitleManager,
   stripesConnect,
 } from '@folio/stripes/core';
 import {
@@ -729,6 +730,7 @@ const PO = ({
       isWithinScope={checkScope}
       scope={document.body}
     >
+      <TitleManager record={orderNumber} />
       <Pane
         id="order-details"
         actionMenu={getPOActionMenu({

--- a/src/components/PurchaseOrder/POVersionView/POVersionView.js
+++ b/src/components/PurchaseOrder/POVersionView/POVersionView.js
@@ -3,6 +3,7 @@ import { memo, useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 
+import { TitleManager } from '@folio/stripes/core';
 import {
   VersionHistoryPane,
   VersionViewContextProvider,
@@ -68,6 +69,7 @@ const POVersionView = ({
       versions={versions}
       versionId={versionId}
     >
+      <TitleManager record={order?.poNumber} />
       <VersionView
         id="order"
         dismissible


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1202

If the detail record displays in the third pane then the HTML Page title should display 
`<<App Title>> - <<Record title>> - FOLIO`

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/5aa287a1-4581-480d-bded-d7c3c3ec0606


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
