### PR TITLE
UIOR-1260 Align the 'finance.*' interfaces versions in accordance with the changes in the descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * *BREAKING* Settings - implement Routing list configuration. Refs UIOR-1249.
 * *BREAKING* Implement central ordering settings for receiving search configuration. Refs UIOR-1232.
 * *BREAKING* Apply changes in the fund schema for the locations field. Refs UIOR-1251.
+* *BREAKING* Align the `finance.*` interfaces versions in accordance with the changes in the descriptor. Refs UIOR-1260.
 
 ## [6.0.2](https://github.com/folio-org/ui-orders/tree/v6.0.2) (2024-04-01)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v6.0.1...v6.0.2)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "finance.exchange-rate": "1.0",
       "finance.expense-classes": "2.0 3.0",
       "finance.funds": "3.0",
-      "finance.transactions": "4.0 5.0",
+      "finance.transactions": "6.0",
       "holdings-storage": "4.4 5.0 6.0",
       "identifier-types": "1.2",
       "instance-formats": "2.0",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1260

Transactions API was changed and requires updates on UI side as well.
https://github.com/folio-org/mod-finance/pull/245/files