### PR TITLE
UIOR-1232 Rename 'Empty' label for the central ordering option

### DIFF
--- a/src/common/constants/constants.js
+++ b/src/common/constants/constants.js
@@ -65,7 +65,7 @@ export const HIDDEN_ORDER_FIELDS_FOR_VERSION_HISTORY = ['nextPolNumber'];
 export const CUSTOM_FIELDS_BACKEND_MODULE_NAME = 'Orders CRUD module';
 
 export const CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH = {
-  empty: 'Empty',
+  activeAffiliationOnly: 'Active affiliation only',
   centralOnly: 'Central only',
   centralDefault: 'Central default',
   activeAffiliationDefault: 'Active affiliation default',

--- a/src/settings/CentralOrdering/CentralOrdering.test.js
+++ b/src/settings/CentralOrdering/CentralOrdering.test.js
@@ -76,12 +76,12 @@ describe('CentralOrdering component', () => {
 
     await user.selectOptions(
       await screen.findByRole('combobox', { name: 'ui-orders.settings.centralOrdering.receivingSearch.label' }),
-      [CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH.empty],
+      [CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH.activeAffiliationDefault],
     );
     await user.click(await screen.findByRole('button', { name: 'stripes-core.button.save' }));
 
     expect(mockUpdateConfigSettings).toHaveBeenCalledWith(expect.objectContaining({
-      value: CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH.empty,
+      value: CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH.activeAffiliationDefault,
     }));
   });
 });

--- a/translations/ui-orders/en.json
+++ b/translations/ui-orders/en.json
@@ -689,7 +689,7 @@
   "settings": "Orders settings",
   "settings.centralOrdering.label": "Central ordering",
   "settings.centralOrdering.receivingSearch.label": "Set default for receiving search",
-  "settings.centralOrdering.receivingSearch.empty": "Empty",
+  "settings.centralOrdering.receivingSearch.activeAffiliationOnly": "Active affiliation only",
   "settings.centralOrdering.receivingSearch.centralOnly": "Central only",
   "settings.centralOrdering.receivingSearch.centralDefault": "Central default",
   "settings.centralOrdering.receivingSearch.activeAffiliationDefault": "Active affiliation default",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1232
https://folio-org.atlassian.net/browse/UIOR-1232?focusedCommentId=209182

Continue of the #1581 

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
![image](https://github.com/folio-org/ui-orders/assets/88109087/f879b944-9135-4a2b-9250-8b9a840761ee)

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
