### PR TITLE
UIOR-1267 Filter order lines by location or holding when central ordering is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Settings - implement Routing address configuration. Refs UIOR-1261.
 * Implement Routing lists accordion. Refs UIOR-1109.
 * Apply code refactoring for custom fields. Refs UIOR-1265.
+* Filter order lines by location or holding when central ordering is enabled. Refs UIOR-1267.
 
 ## [6.0.4](https://github.com/folio-org/ui-orders/tree/v6.0.4) (2024-04-25)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v6.0.3...v6.0.4)

--- a/package.json
+++ b/package.json
@@ -185,8 +185,7 @@
           "ui-orders.custom-fields.view",
           "consortia.publications.item.get",
           "consortia.publications.item.post",
-          "consortia.publications-results.item.get",
-          "consortia.user-tenants.collection.get"
+          "consortia.publications-results.item.get"
         ]
       },
       {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
       "titles": "1.2",
       "users": "15.0 16.0"
     },
+    "optionalOkapiInterfaces": {
+      "consortia": "1.0"
+    },
     "queryResource": "query",
     "icons": [
       {
@@ -179,7 +182,11 @@
           "organizations.organizations.collection.get",
           "organizations-storage.organization-types.collection.get",
           "ui-orders.third-party-services",
-          "ui-orders.custom-fields.view"
+          "ui-orders.custom-fields.view",
+          "consortia.publications.item.get",
+          "consortia.publications.item.post",
+          "consortia.publications-results.item.get",
+          "consortia.user-tenants.collection.get"
         ]
       },
       {

--- a/src/OrderLinesList/OrderLinesFiltersContainer.js
+++ b/src/OrderLinesList/OrderLinesFiltersContainer.js
@@ -1,11 +1,15 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import PropTypes from 'prop-types';
 
-import { stripesConnect } from '@folio/stripes/core';
+import {
+  checkIfUserInCentralTenant,
+  stripesConnect,
+  useStripes,
+} from '@folio/stripes/core';
 import {
   DICT_FUNDS,
   fundsManifest,
+  useCentralOrderingSettings,
 } from '@folio/stripes-acq-components';
 import { OrderLinesFilters } from '@folio/plugin-find-po-line';
 
@@ -14,8 +18,14 @@ import {
 } from '../components/Utils/resources';
 
 const OrderLinesFiltersContainer = ({ resources, activeFilters, applyFilters, disabled }) => {
+  const stripes = useStripes();
+
   const funds = get(resources, `${DICT_FUNDS}.records`);
   const materialTypes = get(resources, 'materialTypes.records', []);
+
+  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
+    enabled: checkIfUserInCentralTenant(stripes),
+  });
 
   return (
     <OrderLinesFilters
@@ -24,6 +34,7 @@ const OrderLinesFiltersContainer = ({ resources, activeFilters, applyFilters, di
       activeFilters={activeFilters}
       applyFilters={applyFilters}
       disabled={disabled}
+      crossTenant={isCentralOrderingEnabled}
     />
   );
 };

--- a/src/OrderLinesList/OrderLinesFiltersContainer.test.js
+++ b/src/OrderLinesList/OrderLinesFiltersContainer.test.js
@@ -3,6 +3,11 @@ import { OrderLinesFilters } from '@folio/plugin-find-po-line';
 
 import OrderLinesFiltersContainer from './OrderLinesFiltersContainer';
 
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useCentralOrderingSettings: jest.fn(() => ({ enabled: true })),
+}));
+
 jest.mock('@folio/plugin-find-po-line/FindPOLine/OrderLinesFilters', () => ({
   OrderLinesFilters: jest.fn().mockReturnValue('OrderLinesFilters'),
 }));


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1267

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Since the locations filter is now a multi-select, it requires passing the current value of the filter (which is an array), not just one element from it.

Should be merged after:
- https://github.com/folio-org/stripes-acq-components/pull/775
- https://github.com/folio-org/ui-plugin-find-po-line/pull/159

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/8d4205f5-2fd2-419f-86e6-ab3cca4dd901


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
