### PR TITLE
UIOR-1233 ECS - Add affiliation dropdown to the PO line location form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Create "Bindery active" flag in POL and order templates. Refs UIOR-1211.
 * Add custom fields to CSV export. Refs UIOR-1231.
 * ECS - Add affiliation dropdown to the PO line location form. Refs UIOR-1233.
+* ECS - Adjust restrict fund by location validation to accommodate central ordering. Refs UIOR-1235.
 
 ## [6.0.4](https://github.com/folio-org/ui-orders/tree/v6.0.4) (2024-04-25)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v6.0.3...v6.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,19 @@
 
 * UX Consistency: HTML page title display when third pane (detail record) displays. Refs UIOR-1202.
 * *BREAKING* Settings - implement Routing list configuration. Refs UIOR-1249.
-* *BREAKING* Implement central ordering settings for receiving search configuration. Refs UIOR-1232.
+* *BREAKING* ECS - Implement central ordering settings for receiving search configuration. Refs UIOR-1232.
 * *BREAKING* Apply changes in the fund schema for the locations field. Refs UIOR-1251.
 * *BREAKING* Align the `finance.*` interfaces versions in accordance with the changes in the descriptor. Refs UIOR-1260.
 * Settings - implement Routing address configuration. Refs UIOR-1261.
 * Implement Routing lists accordion. Refs UIOR-1109.
 * Apply code refactoring for custom fields. Refs UIOR-1265.
-* Filter order lines by location or holding when central ordering is enabled. Refs UIOR-1267.
+* ECS - Filter order lines by location or holding when central ordering is enabled. Refs UIOR-1267.
 * Create routing list modal. Refs UIOR-1191.
 * Add Users to routing list. Refs UIOR-1111.
 * Prioritize users in a routing list by drag and drop list. Refs UIOR-1112.
 * Create "Bindery active" flag in POL and order templates. Refs UIOR-1211.
 * Add custom fields to CSV export. Refs UIOR-1231.
+* ECS - Add affiliation dropdown to the PO line location form. Refs UIOR-1233.
 
 ## [6.0.4](https://github.com/folio-org/ui-orders/tree/v6.0.4) (2024-04-25)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v6.0.3...v6.0.4)

--- a/src/OrderLinesList/Details/OrderLineDetails.js
+++ b/src/OrderLinesList/Details/OrderLineDetails.js
@@ -2,7 +2,6 @@ import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import {
   useCallback,
-  useContext,
   useEffect,
   useState,
 } from 'react';
@@ -16,10 +15,9 @@ import {
 } from '@folio/stripes/core';
 import {
   baseManifest,
-  ConsortiumLocationsContext,
-  LocationsContext,
   Tags,
   useCentralOrderingSettings,
+  useLocationsQuery,
   useShowCallout,
 } from '@folio/stripes-acq-components';
 
@@ -63,7 +61,7 @@ const OrderLineDetails = ({
   const {
     isLoading: isLocationsLoading,
     locations,
-  } = useContext(isCentralOrderingEnabled ? ConsortiumLocationsContext : LocationsContext);
+  } = useLocationsQuery({ consortium: isCentralOrderingEnabled });
 
   const fetchLineDetails = useCallback(
     () => {

--- a/src/OrderLinesList/Details/OrderLineDetails.js
+++ b/src/OrderLinesList/Details/OrderLineDetails.js
@@ -8,15 +8,11 @@ import {
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import { LoadingPane } from '@folio/stripes/components';
-import {
-  checkIfUserInCentralTenant,
-  stripesConnect,
-  stripesShape,
-} from '@folio/stripes/core';
+import { stripesConnect } from '@folio/stripes/core';
 import {
   baseManifest,
   Tags,
-  useCentralOrderingSettings,
+  useCentralOrderingContext,
   useLocationsQuery,
   useShowCallout,
 } from '@folio/stripes-acq-components';
@@ -41,7 +37,6 @@ const OrderLineDetails = ({
   mutator,
   refreshList,
   resources,
-  stripes,
 }) => {
   const lineId = match.params.id;
   const [isLoading, setIsLoading] = useState(true);
@@ -49,9 +44,7 @@ const OrderLineDetails = ({
   const [order, setOrder] = useState({});
   const showToast = useShowCallout();
 
-  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-  });
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   const {
     isLoading: isOrderTemplateLoading,
@@ -254,7 +247,6 @@ OrderLineDetails.propTypes = {
   mutator: PropTypes.object.isRequired,
   refreshList: PropTypes.func.isRequired,
   resources: PropTypes.object.isRequired,
-  stripes: stripesShape.isRequired,
 };
 
 export default stripesConnect(OrderLineDetails);

--- a/src/OrderLinesList/Details/OrderLineDetails.test.js
+++ b/src/OrderLinesList/Details/OrderLineDetails.test.js
@@ -1,17 +1,36 @@
-import { QueryClient, QueryClientProvider } from 'react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
 import { MemoryRouter } from 'react-router';
 
-import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
-import { Tags } from '@folio/stripes-acq-components';
+import {
+  render,
+  screen,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import {
+  Tags,
+  useLocationsQuery,
+} from '@folio/stripes-acq-components';
 
-import { orderLine, order } from 'fixtures';
-import { match, history, location } from 'fixtures/routerMocks';
+import {
+  orderLine,
+  order,
+} from 'fixtures';
+import {
+  match,
+  history,
+  location,
+} from 'fixtures/routerMocks';
 import { POLineView } from '../../components/POLine';
 import OrderLineDetails from './OrderLineDetails';
 
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   Tags: jest.fn().mockReturnValue('Tags'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+  useLocationsQuery: jest.fn(() => ({ locations: [] })),
 }));
 jest.mock('../../components/POLine/POLineView', () => jest.fn().mockReturnValue('POLineView'));
 
@@ -23,9 +42,6 @@ const mutator = {
   },
   order: {
     GET: jest.fn().mockResolvedValue(order),
-  },
-  locations: {
-    GET: jest.fn(),
   },
   materialTypes: {
     GET: jest.fn(),
@@ -69,6 +85,12 @@ const renderOrderLineDetails = (props = {}) => render(
 );
 
 describe('OrderLineDetails', () => {
+  beforeEach(() => {
+    useLocationsQuery
+      .mockClear()
+      .mockReturnValue({ locations: [location] });
+  });
+
   it('should render POLineView', async () => {
     renderOrderLineDetails();
 

--- a/src/OrderLinesList/OrderLinesFiltersContainer.js
+++ b/src/OrderLinesList/OrderLinesFiltersContainer.js
@@ -1,15 +1,11 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import {
-  checkIfUserInCentralTenant,
-  stripesConnect,
-  useStripes,
-} from '@folio/stripes/core';
+import { stripesConnect } from '@folio/stripes/core';
 import {
   DICT_FUNDS,
   fundsManifest,
-  useCentralOrderingSettings,
+  useCentralOrderingContext,
 } from '@folio/stripes-acq-components';
 import { OrderLinesFilters } from '@folio/plugin-find-po-line';
 
@@ -18,14 +14,10 @@ import {
 } from '../components/Utils/resources';
 
 const OrderLinesFiltersContainer = ({ resources, activeFilters, applyFilters, disabled }) => {
-  const stripes = useStripes();
-
   const funds = get(resources, `${DICT_FUNDS}.records`);
   const materialTypes = get(resources, 'materialTypes.records', []);
 
-  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-  });
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   return (
     <OrderLinesFilters

--- a/src/OrderLinesList/OrderLinesFiltersContainer.test.js
+++ b/src/OrderLinesList/OrderLinesFiltersContainer.test.js
@@ -5,7 +5,7 @@ import OrderLinesFiltersContainer from './OrderLinesFiltersContainer';
 
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
-  useCentralOrderingSettings: jest.fn(() => ({ enabled: true })),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
 }));
 
 jest.mock('@folio/plugin-find-po-line/FindPOLine/OrderLinesFilters', () => ({

--- a/src/common/POLFields/FieldsLocation/FieldsLocation.js
+++ b/src/common/POLFields/FieldsLocation/FieldsLocation.js
@@ -10,6 +10,7 @@ import {
   Row,
 } from '@folio/stripes/components';
 import {
+  ConsortiumFieldInventory,
   FieldInventory,
   RepeatableFieldWithValidation,
   TextField,
@@ -33,6 +34,7 @@ import {
 const NO_VALIDATE = undefined;
 
 const FieldsLocation = ({
+  centralOrdering = false,
   changeLocation,
   filterHoldings,
   filterLocations,
@@ -66,6 +68,10 @@ const FieldsLocation = ({
     return NO_VALIDATE;
   };
 
+  const FieldInventoryComponent = centralOrdering
+    ? ConsortiumFieldInventory
+    : FieldInventory;
+
   return (
     <>
       {isQuantityDisabled && (
@@ -91,13 +97,14 @@ const FieldsLocation = ({
         renderField={(field) => (
           <Row>
             <Col xs={6}>
-              <FieldInventory
+              <FieldInventoryComponent
+                affiliationName={`${field}.tenantId`}
                 locationIds={locationIds}
                 locations={locations}
                 holdingName={`${field}.holdingId`}
                 locationName={`${field}.locationId`}
                 onChange={changeLocation}
-                disabled={isPostPendingOrder}
+                isNonInteractive={isPostPendingOrder}
                 required={withValidation}
                 filterHoldings={filterHoldings}
                 filterLocations={filterLocations}
@@ -143,6 +150,7 @@ const FieldsLocation = ({
 };
 
 FieldsLocation.propTypes = {
+  centralOrdering: PropTypes.bool,
   changeLocation: PropTypes.func.isRequired,
   filterHoldings: PropTypes.func,
   filterLocations: PropTypes.func,

--- a/src/components/LayerCollection/LayerPOLine.js
+++ b/src/components/LayerCollection/LayerPOLine.js
@@ -17,7 +17,6 @@ import {
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import {
-  checkIfUserInCentralTenant,
   stripesConnect,
   stripesShape,
 } from '@folio/stripes/core';
@@ -34,7 +33,7 @@ import {
   materialTypesManifest,
   ORDER_FORMATS,
   sourceValues,
-  useCentralOrderingSettings,
+  useCentralOrderingContext,
   useIntegrationConfigs,
   useLocationsQuery,
   useModalToggle,
@@ -138,9 +137,7 @@ function LayerPOLine({
   );
   const { mutateTitle } = useTitleMutation();
 
-  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-  });
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   const {
     isLoading: isLocationsLoading,

--- a/src/components/LayerCollection/LayerPOLine.js
+++ b/src/components/LayerCollection/LayerPOLine.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
@@ -28,17 +27,16 @@ import {
 } from '@folio/stripes/components';
 import {
   baseManifest,
-  ConsortiumLocationsContext,
   DICT_CONTRIBUTOR_NAME_TYPES,
   DICT_IDENTIFIER_TYPES,
   getConfigSetting,
   LIMIT_MAX,
-  LocationsContext,
   materialTypesManifest,
   ORDER_FORMATS,
   sourceValues,
   useCentralOrderingSettings,
   useIntegrationConfigs,
+  useLocationsQuery,
   useModalToggle,
   useShowCallout,
   VENDORS_API,
@@ -147,7 +145,7 @@ function LayerPOLine({
   const {
     isLoading: isLocationsLoading,
     locations,
-  } = useContext(isCentralOrderingEnabled ? ConsortiumLocationsContext : LocationsContext);
+  } = useLocationsQuery({ consortium: isCentralOrderingEnabled });
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedMutator = useMemo(() => mutator, []);

--- a/src/components/LayerCollection/LayerPOLine.test.js
+++ b/src/components/LayerCollection/LayerPOLine.test.js
@@ -1,8 +1,16 @@
-import { QueryClient, QueryClientProvider } from 'react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
 import { MemoryRouter } from 'react-router';
 
 import user from '@folio/jest-config-stripes/testing-library/user-event';
-import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useLocationsQuery } from '@folio/stripes-acq-components';
 
 import {
   order,
@@ -21,7 +29,9 @@ import LayerPOLine from './LayerPOLine';
 
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
   useIntegrationConfigs: jest.fn().mockReturnValue({ integrationConfigs: [], isLoading: false }),
+  useLocationsQuery: jest.fn(),
 }));
 jest.mock('../../common/hooks', () => ({
   useOpenOrderSettings: jest.fn().mockReturnValue({ isFetching: false, openOrderSettings: {} }),
@@ -66,9 +76,6 @@ const defaultProps = {
     orderTemplates: {
       GET: jest.fn().mockResolvedValue(),
     },
-    locations: {
-      GET: jest.fn().mockResolvedValue(),
-    },
     materialTypes: {
       GET: jest.fn().mockResolvedValue(),
     },
@@ -97,9 +104,6 @@ const defaultProps = {
       hasLoaded: true,
     },
     orderTemplates: {
-      hasLoaded: true,
-    },
-    locations: {
       hasLoaded: true,
     },
     identifierTypes: {
@@ -143,7 +147,12 @@ describe('LayerPOLine', () => {
     history.push.mockClear();
     defaultProps.mutator.poLines.PUT.mockClear();
     defaultProps.mutator.poLines.POST.mockClear();
-    useOrder.mockClear().mockReturnValue({ isLoading: false, order });
+    useOrder
+      .mockClear()
+      .mockReturnValue({ isLoading: false, order });
+    useLocationsQuery
+      .mockClear()
+      .mockReturnValue({ locations: [location] });
   });
 
   it('should render POLineForm', async () => {

--- a/src/components/POLine/Location/LocationForm.js
+++ b/src/components/POLine/Location/LocationForm.js
@@ -8,6 +8,7 @@ import {
 } from '../../PurchaseOrder/util';
 
 const LocationForm = ({
+  centralOrdering,
   changeLocation,
   filterHoldings,
   filterLocations,
@@ -22,6 +23,7 @@ const LocationForm = ({
 
   return (
     <FieldsLocation
+      centralOrdering={centralOrdering}
       changeLocation={changeLocation}
       isDisabledToChangePaymentInfo={isDisabledToChangePaymentInfo}
       isPostPendingOrder={isPostPendingOrder}
@@ -38,6 +40,7 @@ const LocationForm = ({
 };
 
 LocationForm.propTypes = {
+  centralOrdering: PropTypes.bool,
   changeLocation: PropTypes.func.isRequired,
   formValues: PropTypes.object.isRequired,
   filterHoldings: PropTypes.func,

--- a/src/components/POLine/Location/LocationView.js
+++ b/src/components/POLine/Location/LocationView.js
@@ -25,6 +25,7 @@ const getLocationFieldName = (fieldName, holdingId) => {
 };
 
 const Location = ({
+  centralOrdering,
   component,
   holdings,
   location,
@@ -110,6 +111,7 @@ const LocationView = ({
 };
 
 Location.propTypes = {
+  centralOrdering: PropTypes.bool,
   component: PropTypes.node,
   location: PropTypes.object,
   locationsMap: PropTypes.object,
@@ -118,6 +120,7 @@ Location.propTypes = {
 };
 
 LocationView.propTypes = {
+  centralOrdering: PropTypes.bool,
   lineLocations: PropTypes.arrayOf(PropTypes.object),
   locations: PropTypes.arrayOf(PropTypes.object),
   name: PropTypes.string,

--- a/src/components/POLine/Location/LocationView.js
+++ b/src/components/POLine/Location/LocationView.js
@@ -25,7 +25,6 @@ const getLocationFieldName = (fieldName, holdingId) => {
 };
 
 const Location = ({
-  centralOrdering,
   component,
   holdings,
   location,
@@ -111,7 +110,6 @@ const LocationView = ({
 };
 
 Location.propTypes = {
-  centralOrdering: PropTypes.bool,
   component: PropTypes.node,
   location: PropTypes.object,
   locationsMap: PropTypes.object,
@@ -120,7 +118,6 @@ Location.propTypes = {
 };
 
 LocationView.propTypes = {
-  centralOrdering: PropTypes.bool,
   lineLocations: PropTypes.arrayOf(PropTypes.object),
   locations: PropTypes.arrayOf(PropTypes.object),
   name: PropTypes.string,

--- a/src/components/POLine/POLine.js
+++ b/src/components/POLine/POLine.js
@@ -2,7 +2,6 @@ import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import {
   useCallback,
-  useContext,
   useEffect,
   useState,
 } from 'react';
@@ -18,13 +17,12 @@ import {
   stripesShape,
 } from '@folio/stripes/core';
 import {
-  ConsortiumLocationsContext,
   DICT_CONTRIBUTOR_NAME_TYPES,
   getErrorCodeFromResponse,
   LINES_API,
-  LocationsContext,
   Tags,
   useCentralOrderingSettings,
+  useLocationsQuery,
   useModalToggle,
   useShowCallout,
 } from '@folio/stripes-acq-components';
@@ -71,7 +69,7 @@ function POLine({
   const {
     isLoading: isLocationsLoading,
     locations,
-  } = useContext(isCentralOrderingEnabled ? ConsortiumLocationsContext : LocationsContext);
+  } = useLocationsQuery({ consortium: isCentralOrderingEnabled });
 
   const fetchOrderLine = useCallback(
     () => mutator.poLine.GET({ params: { query: `id==${lineId}` } })

--- a/src/components/POLine/POLine.js
+++ b/src/components/POLine/POLine.js
@@ -11,17 +11,13 @@ import {
 } from 'react-intl';
 
 import { LoadingPane } from '@folio/stripes/components';
-import {
-  checkIfUserInCentralTenant,
-  stripesConnect,
-  stripesShape,
-} from '@folio/stripes/core';
+import { stripesConnect } from '@folio/stripes/core';
 import {
   DICT_CONTRIBUTOR_NAME_TYPES,
   getErrorCodeFromResponse,
   LINES_API,
   Tags,
-  useCentralOrderingSettings,
+  useCentralOrderingContext,
   useLocationsQuery,
   useModalToggle,
   useShowCallout,
@@ -48,7 +44,6 @@ function POLine({
   mutator,
   poURL,
   resources,
-  stripes,
 }) {
   const intl = useIntl();
   const sendCallout = useShowCallout();
@@ -57,9 +52,7 @@ function POLine({
   const [line, setLine] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
-  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-  });
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   const {
     isLoading: isOrderTemplateLoading,
@@ -267,7 +260,6 @@ POLine.propTypes = {
   mutator: PropTypes.object.isRequired,
   poURL: PropTypes.string,
   resources: PropTypes.object.isRequired,
-  stripes: stripesShape.isRequired,
 };
 
 export default stripesConnect(POLine);

--- a/src/components/POLine/POLine.test.js
+++ b/src/components/POLine/POLine.test.js
@@ -1,8 +1,8 @@
-import { MemoryRouter } from 'react-router';
 import {
   QueryClient,
   QueryClientProvider,
 } from 'react-query';
+import { MemoryRouter } from 'react-router';
 
 import {
   render,

--- a/src/components/POLine/POLine.test.js
+++ b/src/components/POLine/POLine.test.js
@@ -1,10 +1,21 @@
 import { MemoryRouter } from 'react-router';
-import { QueryClient, QueryClientProvider } from 'react-query';
-
-import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
-import { Tags } from '@folio/stripes-acq-components';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
 
 import {
+  render,
+  screen,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import {
+  Tags,
+  useLocationsQuery,
+} from '@folio/stripes-acq-components';
+
+import {
+  location,
   orderLine,
   order,
 } from 'fixtures';
@@ -15,6 +26,8 @@ import POLineView from './POLineView';
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   Tags: jest.fn().mockReturnValue('Tags'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+  useLocationsQuery: jest.fn(() => ({ locations: [] })),
 }));
 jest.mock('../../common/hooks', () => ({
   useOrderTemplate: jest.fn().mockResolvedValue({
@@ -55,9 +68,6 @@ const defaultProps = {
       GET: jest.fn().mockResolvedValue(),
     },
     materialTypes: {
-      GET: jest.fn().mockResolvedValue(),
-    },
-    locations: {
       GET: jest.fn().mockResolvedValue(),
     },
   },
@@ -102,6 +112,9 @@ describe('POLine actions', () => {
     defaultProps.mutator.poLine.GET.mockClear().mockResolvedValue([orderLine]);
     defaultProps.mutator.poLine.PUT.mockClear();
     defaultProps.mutator.poLine.DELETE.mockClear();
+    useLocationsQuery
+      .mockClear()
+      .mockReturnValue({ locations: [location] });
   });
 
   it('should close POLineView and back to order', async () => {

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -106,6 +106,7 @@ const GAME_CHANGER_FIELDS = ['isPackage', 'orderFormat', 'checkinItems', 'packag
 const GAME_CHANGER_TIMEOUT = 50;
 
 function POLineForm({
+  centralOrdering,
   form: { change, batch, getRegisteredFields },
   form,
   initialValues,
@@ -121,6 +122,7 @@ function POLineForm({
   values: formValues,
   enableSaveBtn,
   linesLimit,
+  locations,
   isCreateAnotherChecked = false,
   toggleCreateAnother,
   integrationConfigs = [],
@@ -135,7 +137,6 @@ function POLineForm({
   const accordionStatusRef = useRef();
 
   const identifierTypes = getIdentifierTypesForSelect(parentResources);
-  const locations = parentResources?.locations?.records;
   const lineId = get(initialValues, 'id');
   const saveBtnLabelId = isCreateAnotherChecked ? 'save' : 'saveAndClose';
   const initialDonorOrganizationIds = get(initialValues, 'donorOrganizationIds', []);
@@ -630,6 +631,7 @@ function POLineForm({
                           id={ACCORDION_ID.location}
                         >
                           <LocationForm
+                            centralOrdering={centralOrdering}
                             changeLocation={changeLocation}
                             formValues={formValues}
                             filterHoldings={filterHoldings}
@@ -705,6 +707,7 @@ function POLineForm({
 }
 
 POLineForm.propTypes = {
+  centralOrdering: PropTypes.bool,
   initialValues: PropTypes.object,
   handleSubmit: PropTypes.func.isRequired,
   stripes: stripesShape.isRequired,
@@ -719,6 +722,15 @@ POLineForm.propTypes = {
   values: PropTypes.object.isRequired,
   enableSaveBtn: PropTypes.bool,
   linesLimit: PropTypes.number.isRequired,
+  locations: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    code: PropTypes.string.isRequired,
+    institutionId: PropTypes.string.isRequired,
+    campusId: PropTypes.string.isRequired,
+    libraryId: PropTypes.string.isRequired,
+    tenantId: PropTypes.string,
+  })).isRequired,
   isCreateAnotherChecked: PropTypes.bool,
   toggleCreateAnother: PropTypes.func.isRequired,
   integrationConfigs: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
+++ b/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
@@ -13,7 +13,10 @@ import LocationView from '../../Location/LocationView';
 
 const LOCATIONS_NAME = 'locations';
 
-export const LocationVersionView = ({ version }) => {
+export const LocationVersionView = ({
+  version,
+  centralOrdering = false,
+}) => {
   const versionContext = useContext(VersionViewContext);
 
   const locations = version?.locations;
@@ -37,10 +40,12 @@ export const LocationVersionView = ({ version }) => {
       lineLocations={locations}
       locations={locationsList}
       name={LOCATIONS_NAME}
+      centralOrdering={centralOrdering}
     />
   );
 };
 
 LocationVersionView.propTypes = {
+  centralOrdering: PropTypes.bool,
   version: PropTypes.object.isRequired,
 };

--- a/src/components/POLine/POLineVersionView/POLineVersion.js
+++ b/src/components/POLine/POLineVersionView/POLineVersion.js
@@ -34,7 +34,10 @@ import { PhysicalVersionView } from './PhysicalVersionView';
 import { POLineDetailsVersionView } from './POLineDetailsVersionView';
 import { VendorVersionView } from './VendorVersionView';
 
-const POLineVersion = ({ version }) => {
+const POLineVersion = ({
+  version,
+  centralOrdering = false,
+}) => {
   const accordionStatusRef = useRef();
 
   const orderFormat = version?.orderFormat;
@@ -130,7 +133,10 @@ const POLineVersion = ({ version }) => {
             label={<FormattedMessage id="ui-orders.line.accordion.location" />}
             id={ACCORDION_ID.location}
           >
-            <LocationVersionView version={version} />
+            <LocationVersionView
+              version={version}
+              centralOrdering={centralOrdering}
+            />
           </Accordion>
 
           {showPhresources && (
@@ -166,6 +172,7 @@ const POLineVersion = ({ version }) => {
 };
 
 POLineVersion.propTypes = {
+  centralOrdering: PropTypes.bool,
   version: PropTypes.object.isRequired,
 };
 

--- a/src/components/POLine/POLineVersionView/POLineVersionView.js
+++ b/src/components/POLine/POLineVersionView/POLineVersionView.js
@@ -10,13 +10,9 @@ import {
   IconButton,
   PaneMenu,
 } from '@folio/stripes/components';
+import { TitleManager } from '@folio/stripes/core';
 import {
-  checkIfUserInCentralTenant,
-  TitleManager,
-  useStripes,
-} from '@folio/stripes/core';
-import {
-  useCentralOrderingSettings,
+  useCentralOrderingContext,
   VersionHistoryPane,
   VersionViewContextProvider,
 } from '@folio/stripes-acq-components';
@@ -40,8 +36,6 @@ const POLineVersionView = ({
   location,
   match,
 }) => {
-  const stripes = useStripes();
-
   const { id, lineId, versionId } = match.params;
   const orderLineId = lineId || id;
   const orderId = lineId && id;
@@ -70,12 +64,7 @@ const POLineVersionView = ({
     });
   }, [history, location.search, orderLinePathname]);
 
-  const {
-    enabled: isCentralOrderingEnabled,
-    isLoading: isCentralOrderingSettingsLoading,
-  } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-  });
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   const {
     versions,
@@ -109,7 +98,6 @@ const POLineVersionView = ({
     isOrderLineLoading
     || isHistoryLoading
     || isPOLineVersionLoading
-    || isCentralOrderingSettingsLoading
   );
 
   return (

--- a/src/components/POLine/POLineVersionView/POLineVersionView.test.js
+++ b/src/components/POLine/POLineVersionView/POLineVersionView.test.js
@@ -31,6 +31,7 @@ import POLineVersionView from './POLineVersionView';
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   ExchangeRateValue: jest.fn(() => 'ExchangeRateValue'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
   useLineHoldings: jest.fn(() => ({ isLoading: false, holdings: [] })),
 }));
 jest.mock('@folio/stripes-acq-components/lib/hooks/useUsersBatch', () => ({

--- a/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.js
+++ b/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.js
@@ -1,7 +1,4 @@
-import {
-  useContext,
-  useMemo,
-} from 'react';
+import { useMemo } from 'react';
 import { useQuery } from 'react-query';
 import { useIntl } from 'react-intl';
 import {
@@ -17,8 +14,7 @@ import {
   useOkapiKy,
 } from '@folio/stripes/core';
 import {
-  ConsortiumLocationsContext,
-  LocationsContext,
+  useLocationsQuery,
 } from '@folio/stripes-acq-components';
 
 import {
@@ -68,7 +64,7 @@ export const useSelectedPOLineVersion = ({ versionId, versions, snapshotPath, ce
   const {
     isLoading: isLocationsLoading,
     locations,
-  } = useContext(centralOrdering ? ConsortiumLocationsContext : LocationsContext);
+  } = useLocationsQuery({ consortium: centralOrdering });
 
   const {
     isLoading: isVersionDataLoading,

--- a/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.js
+++ b/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.js
@@ -13,9 +13,7 @@ import {
   useNamespace,
   useOkapiKy,
 } from '@folio/stripes/core';
-import {
-  useLocationsQuery,
-} from '@folio/stripes-acq-components';
+import { useLocationsQuery } from '@folio/stripes-acq-components';
 
 import {
   getMaterialTypes,

--- a/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.js
+++ b/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.js
@@ -13,15 +13,12 @@ import {
 } from 'lodash/fp';
 
 import {
-  checkIfUserInCentralTenant,
   useNamespace,
   useOkapiKy,
-  useStripes,
 } from '@folio/stripes/core';
 import {
   ConsortiumLocationsContext,
   LocationsContext,
-  useCentralOrderingSettings,
 } from '@folio/stripes-acq-components';
 
 import {
@@ -35,10 +32,9 @@ import {
   useOrderLine,
 } from '../../../../common/hooks';
 
-export const useSelectedPOLineVersion = ({ versionId, versions, snapshotPath }, options = {}) => {
+export const useSelectedPOLineVersion = ({ versionId, versions, snapshotPath, centralOrdering }, options = {}) => {
   const intl = useIntl();
   const ky = useOkapiKy();
-  const stripes = useStripes();
   const [namespace] = useNamespace({ key: 'order-line-version-data' });
 
   const deletedRecordLabel = intl.formatMessage({ id: 'stripes-acq-components.versionHistory.deletedRecord' });
@@ -53,12 +49,6 @@ export const useSelectedPOLineVersion = ({ versionId, versions, snapshotPath }, 
 
   const linkedPackagePoLineId = versionSnapshot?.packagePoLineId;
 
-  const {
-    enabled: isCentralOrderingEnabled,
-    isLoading: isCentralOrderingSettingsLoading,
-  } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-  });
   const {
     order,
     isLoading: isOrderLoading,
@@ -78,7 +68,7 @@ export const useSelectedPOLineVersion = ({ versionId, versions, snapshotPath }, 
   const {
     isLoading: isLocationsLoading,
     locations,
-  } = useContext(isCentralOrderingEnabled ? ConsortiumLocationsContext : LocationsContext);
+  } = useContext(centralOrdering ? ConsortiumLocationsContext : LocationsContext);
 
   const {
     isLoading: isVersionDataLoading,
@@ -160,7 +150,6 @@ export const useSelectedPOLineVersion = ({ versionId, versions, snapshotPath }, 
         && !isOrderLineLoading
         && !isLinkedOrderLineLoading
         && !isAcqMethodsLoading
-        && !isCentralOrderingSettingsLoading
         && !isLocationsLoading,
       ),
       ...options,
@@ -173,7 +162,6 @@ export const useSelectedPOLineVersion = ({ versionId, versions, snapshotPath }, 
     || isLinkedOrderLineLoading
     || isAcqMethodsLoading
     || isVersionDataLoading
-    || isCentralOrderingSettingsLoading
     || isLocationsLoading
   );
 

--- a/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.test.js
+++ b/src/components/POLine/hooks/useSelectedPOLineVersion/useSelectedPOLineVersion.test.js
@@ -8,6 +8,7 @@ import { useOkapiKy } from '@folio/stripes/core';
 import {
   LOCATIONS_API,
   MATERIAL_TYPE_API,
+  useLocationsQuery,
   VENDORS_API,
 } from '@folio/stripes-acq-components';
 import {
@@ -26,6 +27,11 @@ import {
   useOrderLine,
 } from '../../../../common/hooks';
 import { useSelectedPOLineVersion } from './useSelectedPOLineVersion';
+
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useLocationsQuery: jest.fn(() => ({ locations: [] })),
+}));
 
 jest.mock('../../../../common/hooks', () => ({
   ...jest.requireActual('../../../../common/hooks'),
@@ -88,6 +94,9 @@ describe('useSelectedPOLineVersion', () => {
         value: 'Purchase',
       }],
     });
+    useLocationsQuery
+      .mockClear()
+      .mockReturnValue({ locations: [location] });
     useOrder.mockClear().mockReturnValue({ isLoading: false, order: { ...order, vendor: vendor.id } });
     useOrderLine.mockClear().mockReturnValue({ isLoading: false, orderLine });
   });

--- a/src/components/POLine/utils.js
+++ b/src/components/POLine/utils.js
@@ -184,6 +184,7 @@ export const getPoLineFieldsLabelMap = ({
     'locations[\\d]': 'ui-orders.line.accordion.location',
     'locations[\\d].holdingId': 'ui-orders.location.holding',
     'locations[\\d].locationId': 'ui-orders.location.nameCode',
+    'locations[\\d].tenantId': 'stripes-acq-components.consortia.affiliations.select.label',
     'locations[\\d].quantity': 'ui-orders.cost.quantity',
     'locations[\\d].quantityPhysical': 'ui-orders.location.quantityPhysical',
     'locations[\\d].quantityElectronic': 'ui-orders.location.quantityElectronic',

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,6 @@ const Orders = ({
 }) => {
   const [isOpen, toggleModal] = useModalToggle();
 
-  // TODO: wrap in central ordering context
-
   const focusSearchField = () => {
     const el = document.getElementById('input-record-search');
 

--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,6 @@ const Orders = ({
 Orders.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
   showSettings: PropTypes.bool,
-  stripes: stripesShape.isRequired,
   location: ReactRouterPropTypes.location.isRequired,
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -176,7 +176,7 @@ const Orders = ({
     );
 
   return (
-    <CentralOrderingContextProvider>
+    <CentralOrderingContextProvider centralTenantOnly>
       {content}
     </CentralOrderingContextProvider>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable filenames/match-exported */
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Route,
@@ -10,6 +9,7 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   AppContextMenu,
+  checkIfUserInCentralTenant,
   stripesShape,
 } from '@folio/stripes/core';
 import {
@@ -23,7 +23,10 @@ import {
 } from '@folio/stripes/components';
 import {
   AcqKeyboardShortcutsModal,
+  ConsortiumLocationsContextProvider,
   handleKeyCommand,
+  LocationsContextProvider as TenantLocationsContextProvider,
+  useCentralOrderingSettings,
   useModalToggle,
 } from '@folio/stripes-acq-components';
 
@@ -43,8 +46,18 @@ import {
 import { Notes } from './common/Notes';
 import { RoutingList } from './components/POLine';
 
-const Orders = ({ match, location, showSettings }) => {
+const Orders = ({
+  match,
+  location,
+  showSettings,
+  stripes,
+}) => {
   const [isOpen, toggleModal] = useModalToggle();
+
+  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
+    enabled: checkIfUserInCentralTenant(stripes),
+  });
+
   const focusSearchField = () => {
     const el = document.getElementById('input-record-search');
 
@@ -52,6 +65,10 @@ const Orders = ({ match, location, showSettings }) => {
       el.focus();
     }
   };
+
+  const LocationsContextProvider = isCentralOrderingEnabled
+    ? ConsortiumLocationsContextProvider
+    : TenantLocationsContextProvider;
 
   const shortcuts = [
     {
@@ -123,40 +140,42 @@ const Orders = ({ match, location, showSettings }) => {
                 </NavList>
               )}
             </AppContextMenu>
-            <Switch>
-              <Route
-                path={ROUTING_LIST_ROUTE}
-                component={RoutingList}
-              />
-              <Route
-                path={ORDER_LINE_CREATE_ROUTE}
-                component={LayerPOLine}
-              />
-              <Route
-                path={ORDER_LINE_EDIT_ROUTE}
-                component={LayerPOLine}
-              />
-              <Route
-                path={ORDER_CREATE_ROUTE}
-                component={LayerPO}
-              />
-              <Route
-                path={ORDER_EDIT_ROUTE}
-                component={LayerPO}
-              />
-              <Route
-                path={ORDER_LINES_ROUTE}
-                component={OrderLinesList}
-              />
-              <Route
-                path={NOTES_ROUTE}
-                component={Notes}
-              />
-              <Route
-                path={path}
-                component={OrdersList}
-              />
-            </Switch>
+            <LocationsContextProvider>
+              <Switch>
+                <Route
+                  path={ROUTING_LIST_ROUTE}
+                  component={RoutingList}
+                />
+                <Route
+                  path={ORDER_LINE_CREATE_ROUTE}
+                  component={LayerPOLine}
+                />
+                <Route
+                  path={ORDER_LINE_EDIT_ROUTE}
+                  component={LayerPOLine}
+                />
+                <Route
+                  path={ORDER_CREATE_ROUTE}
+                  component={LayerPO}
+                />
+                <Route
+                  path={ORDER_EDIT_ROUTE}
+                  component={LayerPO}
+                />
+                <Route
+                  path={ORDER_LINES_ROUTE}
+                  component={OrderLinesList}
+                />
+                <Route
+                  path={NOTES_ROUTE}
+                  component={Notes}
+                />
+                <Route
+                  path={path}
+                  component={OrdersList}
+                />
+              </Switch>
+            </LocationsContextProvider>
           </HasCommand>
         </CommandList>
         {isOpen && (

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,14 @@
 /* eslint-disable filenames/match-exported */
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import {
   Route,
   Switch,
 } from 'react-router-dom';
 import ReactRouterPropTypes from 'react-router-prop-types';
-import { FormattedMessage } from 'react-intl';
 
 import {
   AppContextMenu,
-  checkIfUserInCentralTenant,
   stripesShape,
 } from '@folio/stripes/core';
 import {
@@ -23,10 +22,8 @@ import {
 } from '@folio/stripes/components';
 import {
   AcqKeyboardShortcutsModal,
-  ConsortiumLocationsContextProvider,
+  CentralOrderingContextProvider,
   handleKeyCommand,
-  LocationsContextProvider as TenantLocationsContextProvider,
-  useCentralOrderingSettings,
   useModalToggle,
 } from '@folio/stripes-acq-components';
 
@@ -50,13 +47,10 @@ const Orders = ({
   match,
   location,
   showSettings,
-  stripes,
 }) => {
   const [isOpen, toggleModal] = useModalToggle();
 
-  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-  });
+  // TODO: wrap in central ordering context
 
   const focusSearchField = () => {
     const el = document.getElementById('input-record-search');
@@ -65,10 +59,6 @@ const Orders = ({
       el.focus();
     }
   };
-
-  const LocationsContextProvider = isCentralOrderingEnabled
-    ? ConsortiumLocationsContextProvider
-    : TenantLocationsContextProvider;
 
   const shortcuts = [
     {
@@ -140,42 +130,40 @@ const Orders = ({
                 </NavList>
               )}
             </AppContextMenu>
-            <LocationsContextProvider>
-              <Switch>
-                <Route
-                  path={ROUTING_LIST_ROUTE}
-                  component={RoutingList}
-                />
-                <Route
-                  path={ORDER_LINE_CREATE_ROUTE}
-                  component={LayerPOLine}
-                />
-                <Route
-                  path={ORDER_LINE_EDIT_ROUTE}
-                  component={LayerPOLine}
-                />
-                <Route
-                  path={ORDER_CREATE_ROUTE}
-                  component={LayerPO}
-                />
-                <Route
-                  path={ORDER_EDIT_ROUTE}
-                  component={LayerPO}
-                />
-                <Route
-                  path={ORDER_LINES_ROUTE}
-                  component={OrderLinesList}
-                />
-                <Route
-                  path={NOTES_ROUTE}
-                  component={Notes}
-                />
-                <Route
-                  path={path}
-                  component={OrdersList}
-                />
-              </Switch>
-            </LocationsContextProvider>
+            <Switch>
+              <Route
+                path={ROUTING_LIST_ROUTE}
+                component={RoutingList}
+              />
+              <Route
+                path={ORDER_LINE_CREATE_ROUTE}
+                component={LayerPOLine}
+              />
+              <Route
+                path={ORDER_LINE_EDIT_ROUTE}
+                component={LayerPOLine}
+              />
+              <Route
+                path={ORDER_CREATE_ROUTE}
+                component={LayerPO}
+              />
+              <Route
+                path={ORDER_EDIT_ROUTE}
+                component={LayerPO}
+              />
+              <Route
+                path={ORDER_LINES_ROUTE}
+                component={OrderLinesList}
+              />
+              <Route
+                path={NOTES_ROUTE}
+                component={Notes}
+              />
+              <Route
+                path={path}
+                component={OrdersList}
+              />
+            </Switch>
           </HasCommand>
         </CommandList>
         {isOpen && (
@@ -187,7 +175,11 @@ const Orders = ({
       </>
     );
 
-  return content;
+  return (
+    <CentralOrderingContextProvider>
+      {content}
+    </CentralOrderingContextProvider>
+  );
 };
 
 Orders.propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,7 @@ import {
 } from 'react-router-dom';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
-import {
-  AppContextMenu,
-  stripesShape,
-} from '@folio/stripes/core';
+import { AppContextMenu } from '@folio/stripes/core';
 import {
   checkScope,
   CommandList,

--- a/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateViewContainer.js
+++ b/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateViewContainer.js
@@ -1,18 +1,15 @@
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
-import {
-  useCallback,
-  useContext,
-} from 'react';
+import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import { stripesConnect } from '@folio/stripes/core';
 import {
-  ConsortiumLocationsContext,
   getErrorCodeFromResponse,
-  LocationsContext,
+  useCentralOrderingContext,
+  useLocationsQuery,
   useShowCallout,
 } from '@folio/stripes-acq-components';
 
@@ -43,7 +40,6 @@ const getNewTemplateName = ({ intl, templateName }) => {
 };
 
 function OrderTemplateViewContainer({
-  centralOrdering,
   close,
   match: { params: { id } },
   mutator,
@@ -55,6 +51,7 @@ function OrderTemplateViewContainer({
 }) {
   const intl = useIntl();
   const sendCallout = useShowCallout();
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   const onDuplicateOrderTemplate = useCallback(async ({ id: _, templateName, ...template }) => {
     try {
@@ -100,10 +97,7 @@ function OrderTemplateViewContainer({
     [close, id, sendCallout, showSuccessDeleteMessage],
   );
 
-  const {
-    isLoading: isLocationsLoading,
-    locations,
-  } = useContext(centralOrdering ? ConsortiumLocationsContext : LocationsContext);
+  const { locations } = useLocationsQuery({ consortium: isCentralOrderingEnabled });
 
   const orderTemplate = get(resources, ['orderTemplate', 'records', 0], {});
   const addresses = getAddresses(get(resources, 'addresses.records', []));
@@ -134,7 +128,6 @@ OrderTemplateViewContainer.manifest = Object.freeze({
 });
 
 OrderTemplateViewContainer.propTypes = {
-  centralOrdering: PropTypes.bool,
   close: PropTypes.func.isRequired,
   mutator: PropTypes.object.isRequired,
   match: ReactRouterPropTypes.match.isRequired,

--- a/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateViewContainer.js
+++ b/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateViewContainer.js
@@ -1,13 +1,18 @@
-import React, { useCallback } from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import { withRouter } from 'react-router-dom';
+import {
+  useCallback,
+  useContext,
+} from 'react';
 import { useIntl } from 'react-intl';
-import { get } from 'lodash';
+import { withRouter } from 'react-router-dom';
+import ReactRouterPropTypes from 'react-router-prop-types';
 
 import { stripesConnect } from '@folio/stripes/core';
 import {
+  ConsortiumLocationsContext,
   getErrorCodeFromResponse,
+  LocationsContext,
   useShowCallout,
 } from '@folio/stripes-acq-components';
 
@@ -17,7 +22,6 @@ import {
 } from '../../../common/utils';
 import {
   ADDRESSES,
-  LOCATIONS,
   MATERIAL_TYPES,
   ORDER_TEMPLATE,
 } from '../../../components/Utils/resources';
@@ -39,6 +43,7 @@ const getNewTemplateName = ({ intl, templateName }) => {
 };
 
 function OrderTemplateViewContainer({
+  centralOrdering,
   close,
   match: { params: { id } },
   mutator,
@@ -95,10 +100,14 @@ function OrderTemplateViewContainer({
     [close, id, sendCallout, showSuccessDeleteMessage],
   );
 
+  const {
+    isLoading: isLocationsLoading,
+    locations,
+  } = useContext(centralOrdering ? ConsortiumLocationsContext : LocationsContext);
+
   const orderTemplate = get(resources, ['orderTemplate', 'records', 0], {});
   const addresses = getAddresses(get(resources, 'addresses.records', []));
   const funds = get(resources, 'funds.records', []);
-  const locations = get(resources, 'locations.records', []);
   const materialTypes = get(resources, 'materialTypes.records', []);
 
   return (
@@ -120,12 +129,12 @@ function OrderTemplateViewContainer({
 
 OrderTemplateViewContainer.manifest = Object.freeze({
   addresses: ADDRESSES,
-  locations: LOCATIONS,
   materialTypes: MATERIAL_TYPES,
   orderTemplate: ORDER_TEMPLATE,
 });
 
 OrderTemplateViewContainer.propTypes = {
+  centralOrdering: PropTypes.bool,
   close: PropTypes.func.isRequired,
   mutator: PropTypes.object.isRequired,
   match: ReactRouterPropTypes.match.isRequired,

--- a/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateViewContainer.test.js
+++ b/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateViewContainer.test.js
@@ -1,7 +1,13 @@
 import { MemoryRouter } from 'react-router';
 
-import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useLocationsQuery } from '@folio/stripes-acq-components';
 
+import { location } from 'fixtures';
 import { getCommonErrorMessage } from '../../../common/utils';
 import OrderTemplateViewContainer from './OrderTemplateViewContainer';
 import OrderTemplateView from './OrderTemplateView';
@@ -12,6 +18,11 @@ jest.mock('react-intl', () => ({
     formatMessage: (v) => v,
     formatDate: (v) => v,
   })),
+}));
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+  useLocationsQuery: jest.fn(),
 }));
 jest.mock('../../../common/utils', () => ({
   ...jest.requireActual('../../../common/utils'),
@@ -47,6 +58,12 @@ const template = {
 };
 
 describe('OrderTemplateViewContainer', () => {
+  beforeEach(() => {
+    useLocationsQuery
+      .mockClear()
+      .mockReturnValue({ locations: [location] });
+  });
+
   it('should render order template view', () => {
     renderOrderTemplateViewContainer();
 

--- a/src/settings/OrderTemplates/OrderTemplates.js
+++ b/src/settings/OrderTemplates/OrderTemplates.js
@@ -6,14 +6,7 @@ import { Switch } from 'react-router-dom';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import {
-  checkIfUserInCentralTenant,
-  stripesShape,
-} from '@folio/stripes/core';
-import {
-  ConsortiumLocationsContextProvider,
-  LocationsContextProvider as TenantLocationsContextProvider,
   PermissionedRoute,
-  useCentralOrderingSettings,
   useShowCallout,
 } from '@folio/stripes-acq-components';
 
@@ -31,17 +24,11 @@ function OrderTemplates({
   label,
   match: { path },
   resources,
-  stripes,
 }) {
   const sendCallout = useShowCallout();
   const closePane = useCallback(() => {
     history.push(path);
   }, [history, path]);
-
-  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
-    enabled: checkIfUserInCentralTenant(stripes),
-    queryKey: 'orders-templates',
-  });
 
   const showSuccessDeleteMessage = useCallback(() => {
     sendCallout({
@@ -52,69 +39,56 @@ function OrderTemplates({
 
   const orderTemplatesList = get(resources, ['orderTemplates', 'records'], []);
 
-  const LocationsContextProvider = isCentralOrderingEnabled
-    ? ConsortiumLocationsContextProvider
-    : TenantLocationsContextProvider;
-
   return (
-    <LocationsContextProvider>
-      <Switch>
-        <PermissionedRoute
-          exact
-          path={path}
-          perm="ui-orders.settings.order-templates.view"
-          returnLink={TEMPLATES_RETURN_LINK}
-          returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
-        >
-          <OrderTemplatesList
-            label={label}
-            rootPath={path}
-            orderTemplatesList={orderTemplatesList}
-          />
-        </PermissionedRoute>
+    <Switch>
+      <PermissionedRoute
+        exact
+        path={path}
+        perm="ui-orders.settings.order-templates.view"
+        returnLink={TEMPLATES_RETURN_LINK}
+        returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
+      >
+        <OrderTemplatesList
+          label={label}
+          rootPath={path}
+          orderTemplatesList={orderTemplatesList}
+        />
+      </PermissionedRoute>
 
-        <PermissionedRoute
-          exact
-          path={`${path}/create`}
-          perm="ui-orders.settings.order-templates.create"
-          returnLink={TEMPLATES_RETURN_LINK}
-          returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
-        >
-          <OrderTemplatesEditorContainer
-            centralOrdering={isCentralOrderingEnabled}
-            close={closePane}
-          />
-        </PermissionedRoute>
+      <PermissionedRoute
+        exact
+        path={`${path}/create`}
+        perm="ui-orders.settings.order-templates.create"
+        returnLink={TEMPLATES_RETURN_LINK}
+        returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
+      >
+        <OrderTemplatesEditorContainer close={closePane} />
+      </PermissionedRoute>
 
-        <PermissionedRoute
-          exact
-          path={`${path}/:id/view`}
-          perm="ui-orders.settings.order-templates.view"
-          returnLink={TEMPLATES_RETURN_LINK}
-          returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
-        >
-          <OrderTemplateViewContainer
-            centralOrdering={isCentralOrderingEnabled}
-            close={closePane}
-            rootPath={path}
-            showSuccessDeleteMessage={showSuccessDeleteMessage}
-          />
-        </PermissionedRoute>
+      <PermissionedRoute
+        exact
+        path={`${path}/:id/view`}
+        perm="ui-orders.settings.order-templates.view"
+        returnLink={TEMPLATES_RETURN_LINK}
+        returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
+      >
+        <OrderTemplateViewContainer
+          close={closePane}
+          rootPath={path}
+          showSuccessDeleteMessage={showSuccessDeleteMessage}
+        />
+      </PermissionedRoute>
 
-        <PermissionedRoute
-          exact
-          path={`${path}/:id/edit`}
-          perm="ui-orders.settings.order-templates.edit"
-          returnLink={TEMPLATES_RETURN_LINK}
-          returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
-        >
-          <OrderTemplatesEditorContainer
-            centralOrdering={isCentralOrderingEnabled}
-            close={closePane}
-          />
-        </PermissionedRoute>
-      </Switch>
-    </LocationsContextProvider>
+      <PermissionedRoute
+        exact
+        path={`${path}/:id/edit`}
+        perm="ui-orders.settings.order-templates.edit"
+        returnLink={TEMPLATES_RETURN_LINK}
+        returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
+      >
+        <OrderTemplatesEditorContainer close={closePane} />
+      </PermissionedRoute>
+    </Switch>
   );
 }
 
@@ -127,7 +101,6 @@ OrderTemplates.propTypes = {
   match: ReactRouterPropTypes.match.isRequired,
   history: ReactRouterPropTypes.history.isRequired,
   resources: PropTypes.object.isRequired,
-  stripes: stripesShape.isRequired,
 };
 
 export default OrderTemplates;

--- a/src/settings/OrderTemplates/OrderTemplates.js
+++ b/src/settings/OrderTemplates/OrderTemplates.js
@@ -94,6 +94,7 @@ function OrderTemplates({
           returnLinkLabelId={TEMPLATES_RETURN_LINK_LABEL_ID}
         >
           <OrderTemplateViewContainer
+            centralOrdering={isCentralOrderingEnabled}
             close={closePane}
             rootPath={path}
             showSuccessDeleteMessage={showSuccessDeleteMessage}

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
@@ -78,6 +78,7 @@ const ORDER = {
 };
 
 const OrderTemplatesEditor = ({
+  centralOrdering,
   initialValues,
   identifierTypes,
   isLoading,
@@ -349,6 +350,7 @@ const OrderTemplatesEditor = ({
                         id={ORDER_TEMPLATES_ACCORDION.POL_LOCATION}
                       >
                         <POLineLocationsForm
+                          centralOrdering={centralOrdering}
                           changeLocation={changeLocation}
                           locationIds={locationIds}
                           locations={locations}
@@ -445,6 +447,7 @@ const OrderTemplatesEditor = ({
 };
 
 OrderTemplatesEditor.propTypes = {
+  centralOrdering: PropTypes.bool,
   isLoading: PropTypes.bool,
   values: PropTypes.object.isRequired,
   form: PropTypes.object.isRequired,

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.js
@@ -2,22 +2,24 @@ import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import {
   useCallback,
-  useContext,
   useMemo,
 } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import { withRouter } from 'react-router-dom';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 import { stripesConnect } from '@folio/stripes/core';
 import {
-  ConsortiumLocationsContext,
   DICT_CONTRIBUTOR_NAME_TYPES,
   DICT_IDENTIFIER_TYPES,
   getErrorCodeFromResponse,
-  LocationsContext,
   prefixesResource,
   suffixesResource,
+  useCentralOrderingContext,
+  useLocationsQuery,
   useShowCallout,
 } from '@folio/stripes-acq-components';
 
@@ -49,7 +51,6 @@ import OrderTemplatesEditor from './OrderTemplatesEditor';
 const INITIAL_VALUES = { isPackage: false, hideAll: false };
 
 function OrderTemplatesEditorContainer({
-  centralOrdering = false,
   match: { params: { id } },
   close,
   resources,
@@ -58,6 +59,7 @@ function OrderTemplatesEditorContainer({
 }) {
   const intl = useIntl();
   const showToast = useShowCallout();
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
 
   const saveOrderTemplate = useCallback((values) => {
     const mutatorMethod = id ? mutator.orderTemplate.PUT : mutator.orderTemplate.POST;
@@ -89,7 +91,7 @@ function OrderTemplatesEditorContainer({
   const {
     isLoading: isLocationsLoading,
     locations,
-  } = useContext(centralOrdering ? ConsortiumLocationsContext : LocationsContext);
+  } = useLocationsQuery({ consortium: isCentralOrderingEnabled });
 
   const locationIds = useMemo(() => locations?.map(location => location.id), [locations]);
   const funds = getFundsForSelect(resources);
@@ -133,7 +135,7 @@ function OrderTemplatesEditorContainer({
       vendors={vendors}
       contributorNameTypes={contributorNameTypes}
       stripes={stripes}
-      centralOrdering={centralOrdering}
+      centralOrdering={isCentralOrderingEnabled}
     />
   );
 }
@@ -155,7 +157,6 @@ OrderTemplatesEditorContainer.manifest = Object.freeze({
 });
 
 OrderTemplatesEditorContainer.propTypes = {
-  centralOrdering: PropTypes.bool,
   close: PropTypes.func.isRequired,
   mutator: PropTypes.object.isRequired,
   resources: PropTypes.object.isRequired,

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.js
@@ -1,17 +1,24 @@
-import React, { useCallback, useMemo } from 'react';
+import {
+  useCallback,
+  useMemo,
+} from 'react';
 import PropTypes from 'prop-types';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { withRouter } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { get } from 'lodash';
 
-import { stripesConnect } from '@folio/stripes/core';
+import {
+  checkIfUserInCentralTenant,
+  stripesConnect,
+} from '@folio/stripes/core';
 import {
   DICT_CONTRIBUTOR_NAME_TYPES,
   DICT_IDENTIFIER_TYPES,
   getErrorCodeFromResponse,
   prefixesResource,
   suffixesResource,
+  useCentralOrderingSettings,
   useShowCallout,
 } from '@folio/stripes-acq-components';
 
@@ -43,9 +50,21 @@ import OrderTemplatesEditor from './OrderTemplatesEditor';
 
 const INITIAL_VALUES = { isPackage: false, hideAll: false };
 
-function OrderTemplatesEditorContainer({ match: { params: { id } }, close, resources, stripes, mutator }) {
+function OrderTemplatesEditorContainer({
+  match: { params: { id } },
+  close,
+  resources,
+  stripes,
+  mutator,
+}) {
   const intl = useIntl();
   const showToast = useShowCallout();
+
+  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
+    enabled: checkIfUserInCentralTenant(stripes),
+    queryKey: 'orders-templates',
+  });
+
   const saveOrderTemplate = useCallback((values) => {
     const mutatorMethod = id ? mutator.orderTemplate.PUT : mutator.orderTemplate.POST;
     const templateName = values.templateName?.trim();
@@ -111,6 +130,7 @@ function OrderTemplatesEditorContainer({ match: { params: { id } }, close, resou
       vendors={vendors}
       contributorNameTypes={contributorNameTypes}
       stripes={stripes}
+      centralOrdering={isCentralOrderingEnabled}
     />
   );
 }

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.test.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.test.js
@@ -1,8 +1,8 @@
+import { Form } from 'react-final-form';
 import {
   QueryClient,
   QueryClientProvider,
 } from 'react-query';
-import { Form } from 'react-final-form';
 import { MemoryRouter } from 'react-router-dom';
 
 import {

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.test.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditorContainer.test.js
@@ -1,13 +1,27 @@
-import { QueryClient, QueryClientProvider } from 'react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
 import { Form } from 'react-final-form';
 import { MemoryRouter } from 'react-router-dom';
 
-import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useLocationsQuery } from '@folio/stripes-acq-components';
 
+import { location } from 'fixtures';
 import { getCommonErrorMessage } from '../../../common/utils';
 import OrderTemplatesEditorContainer from './OrderTemplatesEditorContainer';
 import OrderTemplatesEditor from './OrderTemplatesEditor';
 
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+  useLocationsQuery: jest.fn(),
+}));
 jest.mock('../../../common/utils', () => ({
   ...jest.requireActual('../../../common/utils'),
   getCommonErrorMessage: jest.fn(),
@@ -17,11 +31,6 @@ jest.mock('./OrderTemplatesEditor', () => jest.fn().mockReturnValue('OrderTempla
 const defaultProps = {
   close: jest.fn(),
   resources: {
-    locations: {
-      records: [{
-        id: 'locationId',
-      }],
-    },
     identifierTypes: {
       records: [{
         id: 'typeId',
@@ -100,6 +109,12 @@ const renderOrderTemplatesEditorContainer = (props = {}) => render(
 );
 
 describe('OrderTemplatesEditorContainer', () => {
+  beforeEach(() => {
+    useLocationsQuery
+      .mockClear()
+      .mockReturnValue({ locations: [location] });
+  });
+
   it('should render order templates editor', async () => {
     renderOrderTemplatesEditorContainer();
 

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/POLineLocationsForm/POLineLocationsForm.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/POLineLocationsForm/POLineLocationsForm.js
@@ -8,11 +8,18 @@ import {
 
 import { FieldsLocation } from '../../../../common/POLFields';
 
-const POLineLocationsForm = ({ locations, locationIds, changeLocation, formValues }) => {
+const POLineLocationsForm = ({
+  centralOrdering,
+  changeLocation,
+  formValues,
+  locations,
+  locationIds,
+}) => {
   return (
     <Row start="xs">
       <Col xs={12}>
         <FieldsLocation
+          centralOrdering={centralOrdering}
           changeLocation={changeLocation}
           locationIds={locationIds}
           locations={locations}
@@ -25,10 +32,11 @@ const POLineLocationsForm = ({ locations, locationIds, changeLocation, formValue
 };
 
 POLineLocationsForm.propTypes = {
-  locationIds: PropTypes.arrayOf(PropTypes.string),
-  locations: PropTypes.arrayOf(PropTypes.object),
+  centralOrdering: PropTypes.bool,
   changeLocation: PropTypes.func.isRequired,
   formValues: PropTypes.object.isRequired,
+  locationIds: PropTypes.arrayOf(PropTypes.string),
+  locations: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default POLineLocationsForm;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1233
https://folio-org.atlassian.net/browse/UIOR-1235

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Update views and forms throughout the `ui-orders` module where locations are loaded to support ECS mode. In forms where `<FieldInventory>` is used, replace it with `<ConsortiumFieldInventory>`, which will add the ability to define affiliate for a specific field. 

Places to update:
- PO Line view and form
- Order template settings view and form
- PO Line version view

Adjust validation by fund-restricted locations.

## Screenshots

https://github.com/folio-org/stripes-acq-components/assets/88109087/867467a6-2bb1-4a3c-9e68-594cd4e43815

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
