### PR TITLE
UIREC-299: fix allowed number of `quantityPhysical` for creating routing lists

### DIFF
--- a/src/components/POLine/POLineView.js
+++ b/src/components/POLine/POLineView.js
@@ -333,7 +333,7 @@ const POLineView = ({
   );
   const customFieldsValues = get(line, 'customFields', {});
   const numberOfPhysicalUnits = useMemo(() => {
-    return line?.locations?.reduce((acc, { quantityPhysical }) => acc + quantityPhysical, 0);
+    return line?.locations?.reduce((acc, { quantityPhysical = 0 }) => acc + quantityPhysical, 0);
   }, [line?.locations]);
 
   return (


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UIREC-299](https://folio-org.atlassian.net/browse/UIREC-299?focusedCommentId=214082) - fix the allowed number of `quantityPhysical` for creating routing lists due `NaN` type issue
