### PR TITLE
UIOR-1261: fix wrong routing list token for notes

### DIFF
--- a/src/settings/RoutingListConfiguration/constants.js
+++ b/src/settings/RoutingListConfiguration/constants.js
@@ -19,8 +19,8 @@ export const ROUTING_LIST_TOKEN = {
       previewValue: 'Routing Name',
     },
     {
-      token: 'routingList.note',
-      previewValue: 'Routing description',
+      token: 'routingList.notes',
+      previewValue: 'Routing notes',
     },
     {
       token: '#users',


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
UIOR-1261: fix wrong routing list token for notes  [https://folio-org.atlassian.net/browse/UIREC-268?focusedCommentId=214279](https://folio-org.atlassian.net/browse/UIREC-268?focusedCommentId=214279)
