### PR TITLE
UIOR-1235 Fetch consortium holdings by instance ID to include in validation by restricted funds

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
       "users": "15.0 16.0"
     },
     "optionalOkapiInterfaces": {
-      "consortia": "1.0"
+      "consortia": "1.0",
+      "consortium-search": "1.0"
     },
     "queryResource": "query",
     "icons": [
@@ -97,6 +98,7 @@
           "acquisitions-units.memberships.collection.get",
           "acquisitions-units.units.collection.get",
           "configuration.entries.collection.get",
+          "consortium-search.holdings.collection.get",
           "erm.entitlements.collection.get",
           "finance.funds.collection.get",
           "finance.transactions.collection.get",

--- a/src/components/POLine/Location/LocationView.js
+++ b/src/components/POLine/Location/LocationView.js
@@ -11,7 +11,8 @@ import {
 } from '@folio/stripes/components';
 import {
   getHoldingLocationName,
-  useLineHoldings,
+  useCentralOrderingContext,
+  useInstanceHoldingsQuery,
 } from '@folio/stripes-acq-components';
 
 const getLocationFieldName = (fieldName, holdingId) => {
@@ -80,13 +81,14 @@ const Location = ({
 };
 
 const LocationView = ({
+  instanceId,
   locations = [],
   lineLocations = [],
   name,
   ...props
 }) => {
-  const lineHoldingIds = lineLocations.map(({ holdingId }) => holdingId).filter(Boolean);
-  const { isLoading, holdings } = useLineHoldings(lineHoldingIds);
+  const { isCentralOrderingEnabled } = useCentralOrderingContext();
+  const { isLoading, holdings } = useInstanceHoldingsQuery(instanceId, { consortium: isCentralOrderingEnabled });
   const locationsMap = useMemo(() => keyBy(locations, 'id'), [locations]);
 
   if (isLoading) return <Loading />;
@@ -118,6 +120,7 @@ Location.propTypes = {
 };
 
 LocationView.propTypes = {
+  instanceId: PropTypes.string,
   lineLocations: PropTypes.arrayOf(PropTypes.object),
   locations: PropTypes.arrayOf(PropTypes.object),
   name: PropTypes.string,

--- a/src/components/POLine/Location/LocationView.test.js
+++ b/src/components/POLine/Location/LocationView.test.js
@@ -5,7 +5,8 @@ import LocationView from './LocationView';
 jest.mock('@folio/stripes-acq-components', () => {
   return {
     ...jest.requireActual('@folio/stripes-acq-components'),
-    useLineHoldings: jest.fn().mockReturnValue({
+    useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+    useInstanceHoldingsQuery: jest.fn().mockReturnValue({
       isLoading: false,
       holdings: [{ id: 'holdingId' }],
     }),

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -23,7 +23,7 @@ import {
   FundDistributionFieldsFinal,
   handleKeyCommand,
   useFunds,
-  useInstanceHoldings,
+  useInstanceHoldingsQuery,
 } from '@folio/stripes-acq-components';
 import {
   Accordion,
@@ -157,7 +157,10 @@ function POLineForm({
     initialDonorOrganizationIds,
   });
 
-  const { holdings: instanceHoldings } = useInstanceHoldings(instanceId);
+  const {
+    holdings: instanceHoldings,
+    isLoading: isHoldingsLoading,
+  } = useInstanceHoldingsQuery(instanceId, { consortium: centralOrdering });
 
   const shouldUpdateDonorOrganizationIds = useMemo(() => {
     const hasChanged = !isEqual(donorOrganizationIds, formValues?.donorOrganizationIds);
@@ -461,7 +464,13 @@ function POLineForm({
     },
   ];
 
-  if (isFundsLoading || !initialValues) {
+  const isLoading = (
+    !initialValues
+    || isFundsLoading
+    || isHoldingsLoading
+  );
+
+  if (isLoading) {
     return <LoadingPane defaultWidth="fill" onClose={onCancel} />;
   }
 

--- a/src/components/POLine/POLineForm.test.js
+++ b/src/components/POLine/POLineForm.test.js
@@ -13,7 +13,7 @@ import {
 import {
   ORDER_TYPES,
   useFunds,
-  useInstanceHoldings,
+  useInstanceHoldingsQuery,
 } from '@folio/stripes-acq-components';
 
 import {
@@ -29,7 +29,7 @@ jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   Donors: jest.fn(() => 'Donors'),
   useFunds: jest.fn(),
-  useInstanceHoldings: jest.fn(),
+  useInstanceHoldingsQuery: jest.fn(),
 }));
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes/components'),
@@ -181,7 +181,7 @@ describe('POLineForm', () => {
     useFunds
       .mockClear()
       .mockReturnValue({ funds });
-    useInstanceHoldings
+    useInstanceHoldingsQuery
       .mockClear()
       .mockReturnValue({ holdings });
   });

--- a/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
+++ b/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
@@ -5,9 +5,7 @@ import {
   KeyValue,
   NoValue,
 } from '@folio/stripes/components';
-import {
-  VersionViewContext,
-} from '@folio/stripes-acq-components';
+import { VersionViewContext } from '@folio/stripes-acq-components';
 
 import LocationView from '../../Location/LocationView';
 

--- a/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
+++ b/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.js
@@ -37,6 +37,7 @@ export const LocationVersionView = ({
   return (
     <LocationView
       component={renderKeyValueComponent}
+      instanceId={version.instanceId}
       lineLocations={locations}
       locations={locationsList}
       name={LOCATIONS_NAME}

--- a/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.test.js
+++ b/src/components/POLine/POLineVersionView/LocationVersionView/LocationVersionView.test.js
@@ -10,7 +10,8 @@ import { LocationVersionView } from './LocationVersionView';
 jest.mock('@folio/stripes-acq-components', () => {
   return {
     ...jest.requireActual('@folio/stripes-acq-components'),
-    useLineHoldings: jest.fn().mockReturnValue({
+    useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+    useInstanceHoldingsQuery: jest.fn().mockReturnValue({
       isLoading: false,
       holdings: [{ id: 'holdingId' }],
     }),

--- a/src/components/POLine/POLineVersionView/POLineVersionView.test.js
+++ b/src/components/POLine/POLineVersionView/POLineVersionView.test.js
@@ -23,16 +23,14 @@ import {
   ORDER_LINES_ROUTE,
 } from '../../../common/constants';
 import { useOrderLine } from '../../../common/hooks';
-import {
-  useSelectedPOLineVersion,
-} from '../hooks';
+import { useSelectedPOLineVersion } from '../hooks';
 import POLineVersionView from './POLineVersionView';
 
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
   ExchangeRateValue: jest.fn(() => 'ExchangeRateValue'),
   useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
-  useLineHoldings: jest.fn(() => ({ isLoading: false, holdings: [] })),
+  useInstanceHoldingsQuery: jest.fn(() => ({ isLoading: false, holdings: [] })),
 }));
 jest.mock('@folio/stripes-acq-components/lib/hooks/useUsersBatch', () => ({
   useUsersBatch: jest.fn(() => ({ users: [], isLoading: false })),

--- a/src/components/POLine/POLineView.js
+++ b/src/components/POLine/POLineView.js
@@ -460,6 +460,7 @@ const POLineView = ({
                   id={ACCORDION_ID.location}
                 >
                   <LocationView
+                    instanceId={line.instanceId}
                     lineLocations={line.locations}
                     locations={locations}
                   />


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1235

Validation by funds' restricted locations requires checking holdings from all tenants where the instance has holdings. So in the ECS mode, we should use `consortium` search interface to get a list of consortium holdings and filter them by instance ID.

Init PR: #1609 

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/af33aba6-011f-45f0-b75e-78cca3c62e94

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
