### PR TITLE
UIOR-1276 ECS - Add fields indicating the affiliation of locations and holdings for views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 * Add custom fields to CSV export. Refs UIOR-1231.
 * ECS - Add affiliation dropdown to the PO line location form. Refs UIOR-1233.
 * ECS - Adjust restrict fund by location validation to accommodate central ordering. Refs UIOR-1235.
-* Use Save & close button label  stripes-component translation key. Reffs UIOR-1240.
-
+* Use Save & close button label  stripes-component translation key. Refs UIOR-1240.
+* ECS - Add fields indicating the affiliation of locations and holdings for views. Refs UIOR-1276.
 
 ## [6.0.4](https://github.com/folio-org/ui-orders/tree/v6.0.4) (2024-04-25)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v6.0.3...v6.0.4)

--- a/src/components/POLine/Location/LocationView.test.js
+++ b/src/components/POLine/Location/LocationView.test.js
@@ -1,11 +1,20 @@
-import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import {
+  render,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+import {
+  useCentralOrderingContext,
+  useCurrentUserTenants,
+} from '@folio/stripes-acq-components';
+import { affiliations } from '@folio/stripes-acq-components/test/jest/fixtures';
 
 import LocationView from './LocationView';
 
 jest.mock('@folio/stripes-acq-components', () => {
   return {
     ...jest.requireActual('@folio/stripes-acq-components'),
-    useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+    useCentralOrderingContext: jest.fn(),
+    useCurrentUserTenants: jest.fn(),
     useInstanceHoldingsQuery: jest.fn().mockReturnValue({
       isLoading: false,
       holdings: [{ id: 'holdingId' }],
@@ -30,11 +39,29 @@ const renderLocationView = (props = {}) => render(
 );
 
 describe('LocationView', () => {
+  beforeEach(() => {
+    useCentralOrderingContext
+      .mockClear()
+      .mockReturnValue(({ isCentralOrderingEnabled: false }));
+    useCurrentUserTenants
+      .mockClear()
+      .mockReturnValue(affiliations);
+  });
   it('should render \'location\' view', () => {
     renderLocationView();
 
     expect(screen.getByText('ui-orders.location.nameCode')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.location.quantityPhysical')).toBeInTheDocument();
     expect(screen.getByText('ui-orders.location.quantityElectronic')).toBeInTheDocument();
+  });
+
+  describe('ECS mode', () => {
+    it('should render affiliation value for the location when central ordering is enabled', () => {
+      useCentralOrderingContext.mockReturnValue({ isCentralOrderingEnabled: true });
+
+      renderLocationView();
+
+      expect(screen.getByText('stripes-acq-components.consortia.affiliations.select.label')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/POLine/Location/LocationView.test.js
+++ b/src/components/POLine/Location/LocationView.test.js
@@ -59,7 +59,7 @@ describe('LocationView', () => {
     it('should render affiliation value for the location when central ordering is enabled', () => {
       useCentralOrderingContext.mockReturnValue({ isCentralOrderingEnabled: true });
 
-      renderLocationView();
+      renderLocationView({ name: 'consortium.location' });
 
       expect(screen.getByText('stripes-acq-components.consortia.affiliations.select.label')).toBeInTheDocument();
     });

--- a/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateView.js
+++ b/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateView.js
@@ -370,6 +370,7 @@ class OrderTemplateView extends Component {
                       id={ORDER_TEMPLATES_ACCORDION.POL_LOCATION}
                     >
                       <LocationView
+                        instanceId={orderTemplate.instanceId}
                         lineLocations={orderTemplate.locations}
                         locations={locations}
                       />


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1276

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Add an "Affiliation" field for the views, displaying the tenant with which the location/holding is associated.
## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/4d3ba5ca-f3fe-4203-8c07-ee302f9d2f16


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
