### PR TITLE
UIOR-1235 UX: Display loader only for a place that requires it

### DIFF
--- a/src/components/POLine/Location/LocationForm.js
+++ b/src/components/POLine/Location/LocationForm.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 
+import { Loading } from '@folio/stripes/components';
+
 import { FieldsLocation } from '../../../common/POLFields';
 import {
   ifDisabledToChangePaymentInfo,
@@ -13,6 +15,7 @@ const LocationForm = ({
   filterHoldings,
   filterLocations,
   formValues,
+  isLoading = false,
   locationIds,
   locations,
   order,
@@ -20,6 +23,8 @@ const LocationForm = ({
   const isDisabledToChangePaymentInfo = ifDisabledToChangePaymentInfo(order);
   const isPostPendingOrder = !isWorkflowStatusIsPending(order);
   const isQuantityDisabled = !(formValues.checkinItems || formValues.isPackage) && isWorkflowStatusOpen(order);
+
+  if (isLoading) return <Loading />;
 
   return (
     <FieldsLocation
@@ -45,6 +50,7 @@ LocationForm.propTypes = {
   formValues: PropTypes.object.isRequired,
   filterHoldings: PropTypes.func,
   filterLocations: PropTypes.func,
+  isLoading: PropTypes.bool,
   locationIds: PropTypes.arrayOf(PropTypes.string),
   locations: PropTypes.arrayOf(PropTypes.object),
   order: PropTypes.object.isRequired,

--- a/src/components/POLine/Location/LocationForm.test.js
+++ b/src/components/POLine/Location/LocationForm.test.js
@@ -5,6 +5,10 @@ import { render, screen } from '@folio/jest-config-stripes/testing-library/react
 import { order } from 'fixtures';
 import LocationForm from './LocationForm';
 
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  Loading: () => 'Loading',
+}));
 jest.mock('../../../common/POLFields/FieldsLocation', () => jest.fn().mockReturnValue('FieldsLocation'));
 
 const defaultProps = {
@@ -30,7 +34,13 @@ const renderLocationForm = (props = {}) => render(
   />,
 );
 
-describe('EresourcesForm', () => {
+describe('LocationForm', () => {
+  it('should render loader when data is loading', () => {
+    renderLocationForm({ isLoading: true });
+
+    expect(screen.getByText('Loading')).toBeInTheDocument();
+  });
+
   it('should render \'location form\' fields', () => {
     renderLocationForm();
 

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -39,7 +39,6 @@ import {
   HasCommand,
   Icon,
   IconButton,
-  Loading,
   LoadingPane,
   MenuSection,
   Pane,

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -39,6 +39,7 @@ import {
   HasCommand,
   Icon,
   IconButton,
+  Loading,
   LoadingPane,
   MenuSection,
   Pane,
@@ -464,11 +465,7 @@ function POLineForm({
     },
   ];
 
-  const isLoading = (
-    !initialValues
-    || isFundsLoading
-    || isHoldingsLoading
-  );
+  const isLoading = !initialValues || isFundsLoading;
 
   if (isLoading) {
     return <LoadingPane defaultWidth="fill" onClose={onCancel} />;
@@ -640,6 +637,7 @@ function POLineForm({
                           id={ACCORDION_ID.location}
                         >
                           <LocationForm
+                            isLoading={isHoldingsLoading}
                             centralOrdering={centralOrdering}
                             changeLocation={changeLocation}
                             formValues={formValues}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1235

Loading holdings when changing an instance should not completely block the form (by rendering a loading pane), but only the accordion where this data is needed.

This PR is an improvement of #1617. Change log has been already updated.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Pass `isLoading` prop to the location form and display loader on loading data.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/folio-org/ui-orders/assets/88109087/9995e452-f927-409b-ae4b-029eb307be99

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
