### PR TITLE
UIOR-1291 ECS - Check abandoned holdings when unopen order in all dependent tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add title token to printed routing list configuration. Refs UIOR-1287.
 * Display total credited in composite orders. Refs UIOR-1282.
 * Orders app closes after closing Routing list page. Refs UIOR-1299.
+* ECS - Check abandoned holdings when unopen order in all dependent tenants. Refs UIOR-1291.
 
 ## [6.0.4](https://github.com/folio-org/ui-orders/tree/v6.0.4) (2024-04-25)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v6.0.3...v6.0.4)

--- a/src/common/hooks/useOrderLinesAbandonedHoldingsCheck/useOrderLinesAbandonedHoldingsCheck.test.js
+++ b/src/common/hooks/useOrderLinesAbandonedHoldingsCheck/useOrderLinesAbandonedHoldingsCheck.test.js
@@ -11,6 +11,12 @@ import {
 import { UNOPEN_ORDER_ABANDONED_HOLDINGS_TYPES } from '../../constants';
 import { useOrderLinesAbandonedHoldingsCheck } from './useOrderLinesAbandonedHoldingsCheck';
 
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useCentralOrderingContext: jest.fn(() => ({ isCentralOrderingEnabled: false })),
+  useConsortiumTenants: jest.fn(() => ({ tenants: [] })),
+  usePublishCoordinator: jest.fn(() => ({ initPublicationRequest: jest.fn() })),
+}));
 jest.mock('../../utils', () => ({
   ...jest.requireActual('../../utils'),
   checkIndependentPOLinesAbandonedHoldings: jest.fn(() => () => ({})),
@@ -27,8 +33,6 @@ const poLines = [
 ];
 
 const queryClient = new QueryClient();
-
-// eslint-disable-next-line react/prop-types
 const wrapper = ({ children }) => (
   <QueryClientProvider client={queryClient}>
     {children}

--- a/src/common/utils/checkPOLinesAbandonedHoldings.js
+++ b/src/common/utils/checkPOLinesAbandonedHoldings.js
@@ -6,13 +6,13 @@ import { getHoldingPiecesAndItemsCount } from './getHoldingPiecesAndItemsCount';
 
 const REQUEST_CHUNK_SIZE = 5;
 
-export const checkSynchronizedPOLinesAbandonedHoldings = (ky) => async (poLines) => {
+export const checkSynchronizedPOLinesAbandonedHoldings = (ky, options) => async (poLines) => {
   const poLinesChunks = chunk(poLines, REQUEST_CHUNK_SIZE);
 
   const results = await poLinesChunks.reduce(async (acc, poLinesChunk) => {
     const resolvedAcc = await acc;
 
-    const responses = await Promise.all(poLinesChunk.map(checkRelatedHoldings(ky)));
+    const responses = await Promise.all(poLinesChunk.map(checkRelatedHoldings(ky, options)));
 
     return [...resolvedAcc, ...responses];
   }, Promise.resolve([]));
@@ -23,7 +23,7 @@ export const checkSynchronizedPOLinesAbandonedHoldings = (ky) => async (poLines)
   };
 };
 
-export const checkIndependentPOLinesAbandonedHoldings = (ky) => async (poLines) => {
+export const checkIndependentPOLinesAbandonedHoldings = (ky, options) => async (poLines) => {
   const holdingIds = uniq(
     poLines
       .flatMap(({ locations }) => locations)
@@ -36,7 +36,7 @@ export const checkIndependentPOLinesAbandonedHoldings = (ky) => async (poLines) 
   const results = await holdingIdsChunks.reduce(async (acc, holdingIdsChunk) => {
     const resolvedAcc = await acc;
 
-    const responses = await Promise.all(holdingIdsChunk.map(getHoldingPiecesAndItemsCount(ky)));
+    const responses = await Promise.all(holdingIdsChunk.map(getHoldingPiecesAndItemsCount(ky, options)));
 
     return [...resolvedAcc, ...responses];
   }, Promise.resolve([]));

--- a/src/common/utils/getConsortiumPOLineItems.js
+++ b/src/common/utils/getConsortiumPOLineItems.js
@@ -1,0 +1,27 @@
+import queryString from 'query-string';
+
+import {
+  fetchAllRecords,
+  ITEMS_API,
+} from '@folio/stripes-acq-components';
+
+import { getConsortiumPOLineLocationTenants } from './getConsortiumPOLineLocationTenants';
+
+export const getConsortiumPOLineItems = (initPublicationRequest, { signal } = {}) => (poLine) => {
+  const tenants = getConsortiumPOLineLocationTenants(poLine);
+
+  return fetchAllRecords(
+    {
+      GET: async ({ params }) => {
+        const { publicationResults } = await initPublicationRequest({
+          url: `${ITEMS_API}?${queryString.stringify(params, { encode: false })}`,
+          method: 'GET',
+          tenants,
+        }, { signal });
+
+        return publicationResults.flatMap(({ response }) => response.items);
+      },
+    },
+    `purchaseOrderLineIdentifier==${poLine.id}`,
+  );
+};

--- a/src/common/utils/getConsortiumPOLineItems.test.js
+++ b/src/common/utils/getConsortiumPOLineItems.test.js
@@ -1,5 +1,3 @@
-import queryString from 'query-string';
-
 import {
   fetchAllRecords,
   ITEMS_API,

--- a/src/common/utils/getConsortiumPOLineItems.test.js
+++ b/src/common/utils/getConsortiumPOLineItems.test.js
@@ -1,0 +1,106 @@
+import queryString from 'query-string';
+
+import {
+  fetchAllRecords,
+  ITEMS_API,
+} from '@folio/stripes-acq-components';
+
+import { getConsortiumPOLineItems } from './getConsortiumPOLineItems';
+
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  fetchAllRecords: jest.fn(),
+}));
+
+const initPublicationRequestMock = jest.fn();
+
+describe('getConsortiumPOLineItems', () => {
+  const signal = {};
+  const poLine = {
+    id: 'poLineId',
+    locations: [
+      { holdingId: 'hold1', tenantId: 'tenant1' },
+      { holdingId: 'hold2', tenantId: 'tenant2' },
+    ],
+  };
+
+  beforeEach(() => {
+    fetchAllRecords
+      .mockClear()
+      .mockImplementation(async (mutator, query) => {
+        expect(mutator).toHaveProperty('GET');
+        expect(query).toBe('purchaseOrderLineIdentifier==poLineId');
+
+        const records = await mutator.GET({ params: {
+          limit: 100,
+          offset: 0,
+          query,
+        } });
+
+        return records;
+      });
+    initPublicationRequestMock.mockClear();
+  });
+
+  it('should fetch all items related to poLine', async () => {
+    initPublicationRequestMock.mockResolvedValue({
+      publicationResults: [
+        { response: { items: [{ id: 'item1' }, { id: 'item2' }] } },
+        { response: { items: [{ id: 'item3' }] } },
+      ],
+    });
+
+    const items = await getConsortiumPOLineItems(initPublicationRequestMock, { signal })(poLine);
+
+    expect(fetchAllRecords).toHaveBeenCalled();
+    expect(initPublicationRequestMock).toHaveBeenCalledTimes(1);
+
+    expect(initPublicationRequestMock).toHaveBeenNthCalledWith(1, {
+      url: `${ITEMS_API}?limit=100&offset=0&query=purchaseOrderLineIdentifier==poLineId`,
+      method: 'GET',
+      tenants: ['tenant1', 'tenant2'],
+    }, { signal });
+
+    expect(items).toEqual([{ id: 'item1' }, { id: 'item2' }, { id: 'item3' }]);
+  });
+
+  it('should handle empty results', async () => {
+    initPublicationRequestMock.mockResolvedValue({
+      publicationResults: [{ response: { items: [] } }],
+    });
+
+    const items = await getConsortiumPOLineItems(initPublicationRequestMock, { signal })(poLine);
+
+    expect(fetchAllRecords).toHaveBeenCalled();
+    expect(initPublicationRequestMock).toHaveBeenCalledTimes(1);
+
+    expect(initPublicationRequestMock).toHaveBeenNthCalledWith(1, {
+      url: `${ITEMS_API}?limit=100&offset=0&query=purchaseOrderLineIdentifier==poLineId`,
+      method: 'GET',
+      tenants: ['tenant1', 'tenant2'],
+    }, { signal });
+
+    expect(items).toEqual([]);
+  });
+
+  it('should handle multiple tenant results', async () => {
+    initPublicationRequestMock.mockResolvedValue({
+      publicationResults: [
+        { response: { items: [{ id: 'item1' }] } },
+      ],
+    });
+
+    const items = await getConsortiumPOLineItems(initPublicationRequestMock, { signal })(poLine);
+
+    expect(fetchAllRecords).toHaveBeenCalled();
+    expect(initPublicationRequestMock).toHaveBeenCalledTimes(1);
+
+    expect(initPublicationRequestMock).toHaveBeenNthCalledWith(1, {
+      url: `${ITEMS_API}?limit=100&offset=0&query=purchaseOrderLineIdentifier==poLineId`,
+      method: 'GET',
+      tenants: ['tenant1', 'tenant2'],
+    }, { signal });
+
+    expect(items).toEqual([{ id: 'item1' }]);
+  });
+});

--- a/src/common/utils/getConsortiumPOLineLocationTenants.js
+++ b/src/common/utils/getConsortiumPOLineLocationTenants.js
@@ -1,0 +1,3 @@
+export const getConsortiumPOLineLocationTenants = (poLine) => {
+  return poLine.locations?.map(({ tenantId }) => tenantId)?.filter(Boolean) || [];
+};

--- a/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.js
+++ b/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.js
@@ -11,8 +11,10 @@ const PIECE = 'piece';
 const ITEM = 'item';
 
 const buildQueryByHoldingIds = (key) => (itemsChunk) => {
+  const qIndex = key === ITEM ? 'holdingsRecordId' : 'holdingId';
+
   return itemsChunk.length
-    ? `${key === ITEM ? 'holdingsRecordId' : 'holdingId'}==(${itemsChunk.join(' or ')})`
+    ? `${qIndex}==(${itemsChunk.join(' or ')})`
     : '';
 };
 

--- a/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.js
+++ b/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.js
@@ -1,0 +1,65 @@
+import queryString from 'query-string';
+
+import {
+  batchRequest,
+  ITEMS_API,
+  ORDER_PIECES_API,
+} from '@folio/stripes-acq-components';
+import { getConsortiumPOLineLocationTenants } from './getConsortiumPOLineLocationTenants';
+
+const PIECE = 'piece';
+const ITEM = 'item';
+
+const buildQueryByHoldingIds = (key) => (itemsChunk) => {
+  return itemsChunk.length
+    ? `${key === ITEM ? 'holdingsRecordId' : 'holdingId'}==(${itemsChunk.join(' or ')})`
+    : '';
+};
+
+const calculateRecordsCount = (results) => results.reduce((sum, { publicationResults }) => {
+  return publicationResults.reduce((acc, { response }) => acc + response?.totalRecords || 0, sum);
+}, 0);
+
+export const getConsortiumPiecesAndItemsCountByHoldingIds = (initPublicationRequest, { signal }) => {
+  return async (holdingIds, poLine) => {
+    const tenants = getConsortiumPOLineLocationTenants(poLine);
+
+    const piecesResponses = await batchRequest(
+      ({ params }) => (
+        initPublicationRequest({
+          url: `${ORDER_PIECES_API}?${queryString.stringify(params, { encode: false })}`,
+          method: 'GET',
+          tenants,
+        }, { signal })
+      ),
+      holdingIds,
+      buildQueryByHoldingIds(PIECE),
+      { limit: 1 },
+    );
+
+    const itemsResponses = await batchRequest(
+      ({ params }) => (
+        initPublicationRequest({
+          url: `${ITEMS_API}?${queryString.stringify(params, { encode: false })}`,
+          method: 'GET',
+          tenants,
+        }, { signal })
+      ),
+      holdingIds,
+      buildQueryByHoldingIds(ITEM),
+      { limit: 1 },
+    );
+
+    const holdingsPiecesCount = calculateRecordsCount(piecesResponses);
+    const holdingsItemsCount = calculateRecordsCount(itemsResponses);
+
+    return {
+      holdingsPiecesCount,
+      holdingsItemsCount,
+      errors: {
+        pieces: piecesResponses.flatMap(({ publicationErrors }) => publicationErrors),
+        items: itemsResponses.flatMap(({ publicationErrors }) => publicationErrors),
+      },
+    };
+  };
+};

--- a/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.js
+++ b/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.js
@@ -20,7 +20,7 @@ const calculateRecordsCount = (results) => results.reduce((sum, { publicationRes
   return publicationResults.reduce((acc, { response }) => acc + response?.totalRecords || 0, sum);
 }, 0);
 
-export const getConsortiumPiecesAndItemsCountByHoldingIds = (initPublicationRequest, { signal }) => {
+export const getConsortiumPiecesAndItemsCountByHoldingIds = (initPublicationRequest, { signal } = {}) => {
   return async (holdingIds, poLine) => {
     const tenants = getConsortiumPOLineLocationTenants(poLine);
 

--- a/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.test.js
+++ b/src/common/utils/getConsortiumPiecesAndItemsCountByHoldingIds.test.js
@@ -1,0 +1,133 @@
+import queryString from 'query-string';
+
+import {
+  ITEMS_API,
+  ORDER_PIECES_API,
+} from '@folio/stripes-acq-components';
+
+import { getConsortiumPiecesAndItemsCountByHoldingIds } from './getConsortiumPiecesAndItemsCountByHoldingIds';
+
+const initPublicationRequest = jest.fn();
+
+describe('getConsortiumPiecesAndItemsCountByHoldingIds', () => {
+  const poLine = {
+    id: 'poLineId',
+    locations: [
+      { holdingId: 'hold1', tenantId: 'tenant1' },
+      { holdingId: 'hold2', tenantId: 'tenant2' },
+    ],
+  };
+  const holdingIds = poLine.locations.map(location => location.holdingId);
+
+  beforeEach(() => {
+    initPublicationRequest.mockClear();
+  });
+
+  it('should handle successful responses', async () => {
+    initPublicationRequest.mockImplementation(({ url }) => {
+      if (url.includes(ORDER_PIECES_API)) {
+        return Promise.resolve([{ publicationResults: [{ response: { totalRecords: 5 } }], publicationErrors: [] }]);
+      }
+
+      if (url.includes(ITEMS_API)) {
+        return Promise.resolve([{ publicationResults: [{ response: { totalRecords: 10 } }], publicationErrors: [] }]);
+      }
+
+      return Promise.reject(new Error('Unknown API'));
+    });
+
+    const result = await getConsortiumPiecesAndItemsCountByHoldingIds(initPublicationRequest)(holdingIds, poLine);
+
+    expect(result).toEqual({
+      holdingsPiecesCount: 5,
+      holdingsItemsCount: 10,
+      errors: {
+        pieces: [],
+        items: [],
+      },
+    });
+  });
+
+  it('should handle errors in responses', async () => {
+    initPublicationRequest.mockImplementation(({ url }) => {
+      if (url.includes(ORDER_PIECES_API)) {
+        return Promise.resolve([{ publicationResults: [{ response: { totalRecords: 0 } }], publicationErrors: ['Error1'] }]);
+      }
+
+      if (url.includes(ITEMS_API)) {
+        return Promise.resolve([{ publicationResults: [{ response: { totalRecords: 0 } }], publicationErrors: ['Error2'] }]);
+      }
+
+      return Promise.reject(new Error('Test error'));
+    });
+
+    const result = await getConsortiumPiecesAndItemsCountByHoldingIds(initPublicationRequest)(holdingIds, poLine);
+
+    expect(result).toEqual({
+      holdingsPiecesCount: 0,
+      holdingsItemsCount: 0,
+      errors: {
+        pieces: ['Error1'],
+        items: ['Error2'],
+      },
+    });
+  });
+
+  it('should handle mixed successful and error responses', async () => {
+    initPublicationRequest.mockImplementation(({ url }) => {
+      if (url.includes(ORDER_PIECES_API)) {
+        return Promise.resolve([{ publicationResults: [{ response: { totalRecords: 5 } }], publicationErrors: ['Error1'] }]);
+      }
+
+      if (url.includes(ITEMS_API)) {
+        return Promise.resolve([{ publicationResults: [{ response: { totalRecords: 10 } }], publicationErrors: [] }]);
+      }
+
+      return Promise.reject(new Error('Unknown API'));
+    });
+
+    const result = await getConsortiumPiecesAndItemsCountByHoldingIds(initPublicationRequest)(holdingIds, poLine);
+
+    expect(result).toEqual({
+      holdingsPiecesCount: 5,
+      holdingsItemsCount: 10,
+      errors: {
+        pieces: ['Error1'],
+        items: [],
+      },
+    });
+  });
+
+  it('should call initPublicationRequest with correct URL, method, tenants, and signal', async () => {
+    initPublicationRequest.mockImplementation(() => {
+      return Promise.resolve([{ publicationResults: [], publicationErrors: [] }]);
+    });
+
+    const signal = {};
+    const tenants = ['tenant1', 'tenant2'];
+
+    await getConsortiumPiecesAndItemsCountByHoldingIds(initPublicationRequest, { signal })(holdingIds, poLine);
+
+    const getOrderPiecesUrl = () => `${ORDER_PIECES_API}?${queryString.stringify({
+      query: `holdingId==(${holdingIds.join(' or ')})`,
+      limit: 1,
+    }, { encode: false })}`;
+
+    const getItemsUrl = () => `${ITEMS_API}?${queryString.stringify({
+      query: `holdingsRecordId==(${holdingIds.join(' or ')})`,
+      limit: 1,
+    }, { encode: false })}`;
+
+    expect(initPublicationRequest).toHaveBeenNthCalledWith(1, {
+      url: getOrderPiecesUrl(),
+      method: 'GET',
+      tenants,
+    }, { signal });
+
+    expect(initPublicationRequest).toHaveBeenNthCalledWith(2, {
+      url: getItemsUrl(),
+      method: 'GET',
+      tenants,
+    }, { signal });
+  });
+});

--- a/src/common/utils/getHoldingPiecesAndItemsCount.js
+++ b/src/common/utils/getHoldingPiecesAndItemsCount.js
@@ -23,7 +23,7 @@ export const getConsortiumHoldingPiecesCount = (initPublicationRequest, { signal
 
   const { publicationResults } = await initPublicationRequest(publication, { signal });
 
-  return publicationResults.reduce((acc, { response }) => acc + response?.totalRecords, 0);
+  return publicationResults.reduce((acc, { response }) => acc + response?.totalRecords || 0, 0);
 };
 
 export const getHoldingItemsCount = (ky) => async (holdingId) => {
@@ -46,7 +46,7 @@ export const getConsortiumHoldingItemsCount = (initPublicationRequest, { signal,
 
   const { publicationResults } = await initPublicationRequest(publication, { signal });
 
-  return publicationResults.reduce((acc, { response }) => acc + response?.totalRecords, 0);
+  return publicationResults.reduce((acc, { response }) => acc + response?.totalRecords || 0, 0);
 };
 
 export const getHoldingPiecesAndItemsCount = (ky, options = {}) => async (holdingId) => {

--- a/src/common/utils/getPOLineItems.js
+++ b/src/common/utils/getPOLineItems.js
@@ -1,0 +1,17 @@
+import {
+  fetchAllRecords,
+  ITEMS_API,
+} from '@folio/stripes-acq-components';
+
+export const getPOLineItems = (ky) => (poLineId) => {
+  return fetchAllRecords(
+    {
+      GET: async ({ params: searchParams }) => {
+        const { items } = await ky.get(ITEMS_API, { searchParams }).json();
+
+        return items;
+      },
+    },
+    `purchaseOrderLineIdentifier==${poLineId}`,
+  );
+};

--- a/src/common/utils/getPOLinePieces.js
+++ b/src/common/utils/getPOLinePieces.js
@@ -1,0 +1,17 @@
+import {
+  fetchAllRecords,
+  ORDER_PIECES_API,
+} from '@folio/stripes-acq-components';
+
+export const getPOLinePieces = (ky) => (poLine) => {
+  return fetchAllRecords(
+    {
+      GET: async ({ params: searchParams }) => {
+        const { pieces } = await ky.get(ORDER_PIECES_API, { searchParams }).json();
+
+        return pieces;
+      },
+    },
+    `poLineId==${poLine.id}`,
+  );
+};

--- a/src/common/utils/index.js
+++ b/src/common/utils/index.js
@@ -12,6 +12,7 @@ export { default as getCreateInventorySetting } from './getCreateInventorySettin
 export * from './getHoldingPiecesAndItemsCount';
 export * from './getOrganizationsByIds';
 export * from './getLocations';
+export * from './getPOLinePieces';
 export * from './getMaterialTypes';
 export * from './getUserNameById';
 export * from './getVersionMetadata';

--- a/src/components/PurchaseOrder/UnopenOrderConfirmationModal/UnopenOrderConfirmationModal.js
+++ b/src/components/PurchaseOrder/UnopenOrderConfirmationModal/UnopenOrderConfirmationModal.js
@@ -95,9 +95,9 @@ export const UnopenOrderConfirmationModal = ({
       aria-label={modalLabel}
     >
       {
-      isFetching
-        ? <Loading />
-        : <FormattedMessage id={`ui-orders.unopenOrderModal.message.${modalType}`} />
+        isFetching
+          ? <Loading />
+          : <FormattedMessage id={`ui-orders.unopenOrderModal.message.${modalType}`} />
       }
     </Modal>
   );


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1291

Central ordering allows an order to have PO Lines with locations/holdings from different tenants. After opening the order, pieces and items may be created in these locations/holdings (depending on the "Receiving workflow" value). During the unopen operation, related items and pieces are deleted, and the created holdings may remain empty in different tenants. Therefore, a check for abandoned holdings in all related tenants is required.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

Send requests to check for the presence of items and pieces in holdings to tenants related to the PO.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/87cea34e-3958-4f45-b42f-508e3dfa6ee5


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
