### PR TITLE
UIOR-1339 Fix print order action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.1.0 (IN PROGRESS)
 
 * import DOMPurify in right way. Refs UIOR-1340.
+* Fix print order action. Refs UIOR-1339.
 
 ## [7.0.0](https://github.com/folio-org/ui-orders/tree/v7.0.0) (2024-11-01)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v6.0.4...v7.0.0)

--- a/src/PrintOrder/PrintOrder.js
+++ b/src/PrintOrder/PrintOrder.js
@@ -37,7 +37,7 @@ export const PrintOrderComponent = ({ mutator, order, orderLine, onCancel }) => 
       const { compositePoLines } = order;
       const linesToPrint = orderLine ? [orderLine] : compositePoLines;
       const printData = compositePoLines?.length
-        ? { lines: await getExportData(mutator, linesToPrint, [order], intl) }
+        ? { lines: await getExportData(mutator, linesToPrint, [order], [], intl) }
         : await getOrderPrintData(ky, order);
 
       let poLineTotals = {};


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIOR-1339

## Purpose
* Fix broken 'Print order' action

## Approach
* Add missing argument to `getExportData` method
