### PR TITLE
[UIOR-1405] Add `settings.enabled` as a subpermission to all permission sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.1.0 (IN PROGRESS)
 
 * Provide `signal` from `useQuery` function to the http client (ky). Refs UIOR-1363.
+* Add `settings.enabled` as a subpermission to all permission sets so they can be accessed in the UI if enabled individually. Refs UIOR-1405.
 
 ## [8.0.0](https://github.com/folio-org/ui-orders/tree/v8.0.0) (2025-03-13)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v7.0.4...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -382,6 +382,7 @@
         "description": "",
         "visible": true,
         "subPermissions": [
+          "settings.orders.enabled",
           "configuration.entries.collection.get",
           "orders-storage.custom-fields.collection.get",
           "orders-storage.custom-fields.item.get",
@@ -417,6 +418,7 @@
         "permissionName": "ui-orders.settings.number-generator.manage",
         "displayName": "Settings (Orders): Manage number generator options",
         "subPermissions": [
+          "settings.orders.enabled",
           "orders-storage.settings.collection.get",
           "orders-storage.settings.item.get",
           "orders-storage.settings.item.post",
@@ -430,8 +432,8 @@
         "description": "",
         "visible": true,
         "subPermissions": [
-          "addresstypes.collection.get",
           "settings.orders.enabled",
+          "addresstypes.collection.get",
           "ui-orders.settings.order-templates.view",
           "configuration.entries.collection.get",
           "configuration.entries.item.get",


### PR DESCRIPTION
* Fulfills [UIOR-1405](https://folio-org.atlassian.net/browse/UIOR-1405)
* By doing this, all permission sets can be accessed in the UI if enabled individually.