### PR TITLE
UIOR-1411 Provide specific query key to the `useCentralOrderingSettings` in orders settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `settings.enabled` as a subpermission to all permission sets so they can be accessed in the UI if enabled individually. Refs UIOR-1405.
 * Display empty value instead of "Invalid link" for affiliation field if no value is assigned to it. Fixes UIOR-1369.
 * Allow editing of location information for PO lines with independent workflow in open order. Refs UIOR-1368.
+* Provide specific query key to the `useCentralOrderingSettings` in orders settings. Refs UIOR-1411.
 
 ## [8.0.0](https://github.com/folio-org/ui-orders/tree/v8.0.0) (2025-03-13)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v7.0.4...v8.0.0)

--- a/src/settings/OrdersSettings.js
+++ b/src/settings/OrdersSettings.js
@@ -1,7 +1,10 @@
 import { FormattedMessage } from 'react-intl';
 
 import { LoadingPane } from '@folio/stripes/components';
-import { useStripes } from '@folio/stripes/core';
+import {
+  useNamespace,
+  useStripes,
+} from '@folio/stripes/core';
 import { Settings } from '@folio/stripes/smart-components';
 import { useCentralOrderingSettings } from '@folio/stripes-acq-components';
 
@@ -15,6 +18,7 @@ const paneTitle = <FormattedMessage id="ui-orders.settings.index.paneTitle" />;
 
 const OrdersSettings = (props) => {
   const stripes = useStripes();
+  const [namespace] = useNamespace('orders-settings');
 
   const {
     key,
@@ -24,6 +28,7 @@ const OrdersSettings = (props) => {
 
   const { isLoading: isCentralOrderingSettingsLoading } = useCentralOrderingSettings({
     enabled: stripes.hasInterface('consortia'),
+    queryKey: [namespace],
     onSuccess: (d) => {
       if (d?.value === 'true') {
         insertSection(NETWORK_ORDERING_SECTION);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1411

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/0272d1f7-d0c3-4633-827e-18dbeef17f07


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
