### PR TITLE
UIOR-1435: Add `PO_LINE_CONFIG_NAME_PREFIX` constant and use it in the custom field components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add "Order template categories" field to order template. Refs UIOR-1401.
 * Add Claiming active, Claiming interval fields, Donor information accordion to Template. Refs UIOR-1393.
 * Add ability to hide optional fields in the order template form. Refs UIOR-1394.
+* Add PO_LINE_CONFIG_NAME_PREFIX constant and use it in the custom field components. Fixes UIOR-1435.
 
 ## [8.0.3](https://github.com/folio-org/ui-orders/tree/v8.0.2) (2025-04-10)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v8.0.2...v8.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add "Order template categories" field to order template. Refs UIOR-1401.
 * Add Claiming active, Claiming interval fields, Donor information accordion to Template. Refs UIOR-1393.
 * Add ability to hide optional fields in the order template form. Refs UIOR-1394.
-* Add PO_LINE_CONFIG_NAME_PREFIX constant and use it in the custom field components. Fixes UIOR-1435.
+* Add prefix constants and use them in the custom field components. Fixes UIOR-1435.
 
 ## [8.0.3](https://github.com/folio-org/ui-orders/tree/v8.0.2) (2025-04-10)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v8.0.2...v8.0.3)

--- a/src/common/constants/constants.js
+++ b/src/common/constants/constants.js
@@ -73,3 +73,5 @@ export const CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH = {
 };
 
 export const SUBMIT_ACTION_FIELD = '__submitAction__';
+
+export const PO_LINE_CONFIG_NAME_PREFIX = 'po_lines';

--- a/src/common/constants/constants.js
+++ b/src/common/constants/constants.js
@@ -75,3 +75,4 @@ export const CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH = {
 export const SUBMIT_ACTION_FIELD = '__submitAction__';
 
 export const PO_LINE_CONFIG_NAME_PREFIX = 'po_lines';
+export const PO_CONFIG_NAME_PREFIX = 'purchase_orders';

--- a/src/components/POLine/POLineForm.js
+++ b/src/components/POLine/POLineForm.js
@@ -61,6 +61,7 @@ import {
 
 import {
   ENTITY_TYPE_PO_LINE,
+  PO_LINE_CONFIG_NAME_PREFIX,
   SUBMIT_ACTION_FIELD,
 } from '../../common/constants';
 import {
@@ -791,6 +792,7 @@ function POLineForm({
                               entityType={ENTITY_TYPE_PO_LINE}
                               fieldComponent={Field}
                               finalFormCustomFieldsValues={customFieldsValues}
+                              configNamePrefix={PO_LINE_CONFIG_NAME_PREFIX}
                               onComponentLoad={handleCustomFieldsLoaded}
                             />
                           </IfFieldVisible>

--- a/src/components/POLine/POLineView.js
+++ b/src/components/POLine/POLineView.js
@@ -74,6 +74,7 @@ import {
   REEXPORT_SOURCES,
   ORDER_LINES_ROUTE,
   ROUTING_LIST_ROUTE,
+  PO_LINE_CONFIG_NAME_PREFIX,
 } from '../../common/constants';
 import { useExportHistory } from '../../common/hooks';
 import { isOngoing } from '../../common/POFields';
@@ -567,6 +568,7 @@ const POLineView = ({
                     backendModuleName={CUSTOM_FIELDS_ORDERS_BACKEND_NAME}
                     customFieldsValues={customFieldsValues}
                     entityType={ENTITY_TYPE_PO_LINE}
+                    configNamePrefix={PO_LINE_CONFIG_NAME_PREFIX}
                   />
                 </IfVisible>
               </AccordionSet>

--- a/src/components/PurchaseOrder/PO.js
+++ b/src/components/PurchaseOrder/PO.js
@@ -71,6 +71,7 @@ import {
   ERROR_CODES,
   INVOICES_ROUTE,
   ORDERS_ROUTE,
+  PO_CONFIG_NAME_PREFIX,
   REEXPORT_SOURCES,
   WORKFLOW_STATUS,
 } from '../../common/constants';
@@ -866,6 +867,7 @@ const PO = ({
                 backendModuleName={CUSTOM_FIELDS_ORDERS_BACKEND_NAME}
                 customFieldsValues={customFieldsValues}
                 entityType={ENTITY_TYPE_ORDER}
+                configNamePrefix={PO_CONFIG_NAME_PREFIX}
               />
             </IfVisible>
 

--- a/src/components/PurchaseOrder/POForm.js
+++ b/src/components/PurchaseOrder/POForm.js
@@ -43,6 +43,7 @@ import {
 
 import {
   ENTITY_TYPE_ORDER,
+  PO_CONFIG_NAME_PREFIX,
   SUBMIT_ACTION_FIELD,
 } from '../../common/constants';
 import { useErrorAccordionStatus } from '../../common/hooks';
@@ -438,6 +439,7 @@ const POForm = ({
                               entityType={ENTITY_TYPE_ORDER}
                               fieldComponent={Field}
                               finalFormCustomFieldsValues={customFieldsValues}
+                              configNamePrefix={PO_CONFIG_NAME_PREFIX}
                             />
                           </IfFieldVisible>
                         </AccordionSet>

--- a/src/settings/CustomFieldsSettings.js
+++ b/src/settings/CustomFieldsSettings.js
@@ -17,6 +17,7 @@ import {
 import {
   ENTITY_TYPE_ORDER,
   ENTITY_TYPE_PO_LINE,
+  PO_LINE_CONFIG_NAME_PREFIX,
 } from '../common/constants';
 
 const CustomFieldsSettings = () => {
@@ -62,6 +63,7 @@ const CustomFieldsSettings = () => {
             entityType={ENTITY_TYPE_PO_LINE}
             editRoute={`${basePOL}/edit`}
             permissions={permissions}
+            configNamePrefix={PO_LINE_CONFIG_NAME_PREFIX}
           />
         </TitleManager>
       </Route>
@@ -72,6 +74,7 @@ const CustomFieldsSettings = () => {
             entityType={ENTITY_TYPE_PO_LINE}
             viewRoute={basePOL}
             permissions={permissions}
+            configNamePrefix={PO_LINE_CONFIG_NAME_PREFIX}
           />
         </TitleManager>
       </Route>

--- a/src/settings/CustomFieldsSettings.js
+++ b/src/settings/CustomFieldsSettings.js
@@ -17,6 +17,7 @@ import {
 import {
   ENTITY_TYPE_ORDER,
   ENTITY_TYPE_PO_LINE,
+  PO_CONFIG_NAME_PREFIX,
   PO_LINE_CONFIG_NAME_PREFIX,
 } from '../common/constants';
 
@@ -42,6 +43,7 @@ const CustomFieldsSettings = () => {
             entityType={ENTITY_TYPE_ORDER}
             editRoute={`${basePO}/edit`}
             permissions={permissions}
+            configNamePrefix={PO_CONFIG_NAME_PREFIX}
           />
         </TitleManager>
       </Route>
@@ -52,6 +54,7 @@ const CustomFieldsSettings = () => {
             entityType={ENTITY_TYPE_ORDER}
             viewRoute={basePO}
             permissions={permissions}
+            configNamePrefix={PO_CONFIG_NAME_PREFIX}
           />
         </TitleManager>
       </Route>

--- a/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateView.js
+++ b/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateView.js
@@ -38,6 +38,7 @@ import {
 import {
   ENTITY_TYPE_ORDER,
   ENTITY_TYPE_PO_LINE,
+  PO_CONFIG_NAME_PREFIX,
   PO_LINE_CONFIG_NAME_PREFIX,
 } from '../../../common/constants';
 import { isOngoing } from '../../../common/POFields';
@@ -461,6 +462,7 @@ class OrderTemplateView extends Component {
                       backendModuleName={CUSTOM_FIELDS_ORDERS_BACKEND_NAME}
                       customFieldsValues={customFieldsValues}
                       entityType={ENTITY_TYPE_ORDER}
+                      configNamePrefix={PO_CONFIG_NAME_PREFIX}
                     />
 
                     <ViewCustomFieldsRecord

--- a/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateView.js
+++ b/src/settings/OrderTemplates/OrderTemplateView/OrderTemplateView.js
@@ -38,6 +38,7 @@ import {
 import {
   ENTITY_TYPE_ORDER,
   ENTITY_TYPE_PO_LINE,
+  PO_LINE_CONFIG_NAME_PREFIX,
 } from '../../../common/constants';
 import { isOngoing } from '../../../common/POFields';
 import { PODetailsView } from '../../../components/PurchaseOrder/PODetails';
@@ -467,6 +468,7 @@ class OrderTemplateView extends Component {
                       backendModuleName={CUSTOM_FIELDS_ORDERS_BACKEND_NAME}
                       customFieldsValues={customFieldsValues}
                       entityType={ENTITY_TYPE_PO_LINE}
+                      configNamePrefix={PO_LINE_CONFIG_NAME_PREFIX}
                     />
                   </AccordionSet>
                 </Col>

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
@@ -36,6 +36,7 @@ import {
 import {
   ENTITY_TYPE_ORDER,
   ENTITY_TYPE_PO_LINE,
+  PO_CONFIG_NAME_PREFIX,
   PO_LINE_CONFIG_NAME_PREFIX,
   WORKFLOW_STATUS,
 } from '../../../common/constants';
@@ -465,6 +466,7 @@ const OrderTemplatesEditor = ({
                         finalFormCustomFieldsValues={customFieldsValues}
                         displayWhenClosed={customPOFieldsVisibilityControl}
                         displayWhenOpen={customPOFieldsVisibilityControl}
+                        configNamePrefix={PO_CONFIG_NAME_PREFIX}
                       />
                       <EditCustomFieldsRecord
                         accordionId={ORDER_TEMPLATES_ACCORDION.POL_CUSTOM_FIELDS}

--- a/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
+++ b/src/settings/OrderTemplates/OrderTemplatesEditor/OrderTemplatesEditor.js
@@ -36,6 +36,7 @@ import {
 import {
   ENTITY_TYPE_ORDER,
   ENTITY_TYPE_PO_LINE,
+  PO_LINE_CONFIG_NAME_PREFIX,
   WORKFLOW_STATUS,
 } from '../../../common/constants';
 import {
@@ -474,6 +475,7 @@ const OrderTemplatesEditor = ({
                         finalFormCustomFieldsValues={customFieldsValues}
                         displayWhenClosed={customPOLineFieldsVisibilityControl}
                         displayWhenOpen={customPOLineFieldsVisibilityControl}
+                        configNamePrefix={PO_LINE_CONFIG_NAME_PREFIX}
                       />
                     </AccordionSet>
                   </Col>


### PR DESCRIPTION
## Description
When multiple instances of the `EditCustomFieldsSettings`/ `EditCustomFieldsRecord`/ `ViewCustomFieldsRecord`/ `ViewCustomFieldsSettings` UI component, each associated with a distinct `entityType`, are used within a single application, then modifying the accordion label in one component results in an unintended change to the label in all other components. This behavior contradicts the expected functionality, causing inconsistency in the labeling of accordion sections based on entityTypes.

The issue arises due to the request sent to the configurations API to store the accordion label, which utilizes a single `configName` for all entityTypes.

Using a single `configName` for multiple entityTypes, leads to a universal change in the accordion label across all instances of the `EditCustomFieldsSettings`/ `EditCustomFieldsRecord`/ `ViewCustomFieldsRecord`/ `ViewCustomFieldsSettings` components, regardless of their associated entityTypes.

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1584

## Approach
Use `configNamePrefix` property to extend `configName` for the PO line and leave the PO as is.

## Issues
[UIOR-1435](https://folio-org.atlassian.net/browse/UIOR-1435)

## Screencasts


https://github.com/user-attachments/assets/fa6adc9f-cb8d-4b70-83b1-ac87f53aee48

