### PR TITLE
UIOR-1420 Display an error toast only when PO Line locations violate fund restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Memoize the callback used in `useEffect`. Fixes UIOR-1423.
 * Fix "Activation due" date in the export CSV report. Fixes UIOR-1427.
 * Allow users to edit package name for an open order. Refs UIOR-1430.
+* Display an error toast only when PO Line locations violate fund restrictions. Fixes UIOR-1420.
 
 ## [8.0.3](https://github.com/folio-org/ui-orders/tree/v8.0.2) (2025-04-10)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v8.0.2...v8.0.3)

--- a/src/components/POLine/POLineDetails/POLineDetails.js
+++ b/src/components/POLine/POLineDetails/POLineDetails.js
@@ -1,7 +1,6 @@
 import get from 'lodash/get';
 import isNil from 'lodash/isNil';
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { ClipCopy } from '@folio/stripes/smart-components';
@@ -18,12 +17,10 @@ import {
   FolioFormattedTime,
   IfVisible,
   sourceLabels,
-  useShowCallout,
 } from '@folio/stripes-acq-components';
 
 import { useAcqMethod } from '../../../common/hooks';
 import { getTranslatedAcqMethod } from '../../Utils/getTranslatedAcqMethod';
-import { useIsFundsRestrictedByLocationIds } from '../hooks';
 
 const invalidAcqMethod = <FormattedMessage id="ui-orders.acquisitionMethod.invalid" />;
 
@@ -46,20 +43,8 @@ export const getAcquisitionMethodValue = (acqMethodId, acqMethod) => {
 };
 
 const POLineDetails = ({ line, hiddenFields }) => {
-  const showCallout = useShowCallout();
   const receiptDate = get(line, 'receiptDate');
   const { acqMethod, isLoading } = useAcqMethod(line.acquisitionMethod);
-
-  const { hasLocationRestrictedFund } = useIsFundsRestrictedByLocationIds(line);
-
-  useEffect(() => {
-    if (hasLocationRestrictedFund) {
-      showCallout({
-        messageId: 'ui-orders.errors.poLineHasLocationRestrictedFund',
-        type: 'error',
-      });
-    }
-  }, [hasLocationRestrictedFund, showCallout]);
 
   return (
     <>

--- a/src/components/POLine/POLineView.js
+++ b/src/components/POLine/POLineView.js
@@ -54,6 +54,7 @@ import {
   TagsBadge,
   useAcqRestrictions,
   useModalToggle,
+  useShowCallout,
   VersionHistoryButton,
 } from '@folio/stripes-acq-components';
 
@@ -102,9 +103,8 @@ import {
   ERESOURCES,
   PHRESOURCES,
 } from './const';
-import {
-  isCancelableLine,
-} from './utils';
+import { useIsFundsRestrictedByLocationIds } from './hooks';
+import { isCancelableLine } from './utils';
 
 const initialAccordionStatus = {
   CostDetails: true,
@@ -144,6 +144,8 @@ const POLineView = ({
 }) => {
   const intl = useIntl();
   const stripes = useStripes();
+  const showCallout = useShowCallout();
+
   const [showConfirmDelete, toggleConfirmDelete] = useModalToggle();
   const [showConfirmCancel, toggleConfirmCancel] = useModalToggle();
   const [isPrintOrderModalOpened, togglePrintOrderModal] = useModalToggle();
@@ -168,6 +170,17 @@ const POLineView = ({
   } = useExportHistory([line.id]);
 
   const isCancelable = isCancelableLine(line, order);
+
+  const { hasLocationRestrictedFund } = useIsFundsRestrictedByLocationIds(line);
+
+  useEffect(() => {
+    if (hasLocationRestrictedFund) {
+      showCallout({
+        messageId: 'ui-orders.errors.poLineHasLocationRestrictedFund',
+        type: 'error',
+      });
+    }
+  }, [hasLocationRestrictedFund, showCallout]);
 
   useEffect(() => {
     setHiddenFields(orderTemplate.hiddenFields);

--- a/src/components/POLine/hooks/useFundsById/useFundsById.js
+++ b/src/components/POLine/hooks/useFundsById/useFundsById.js
@@ -24,6 +24,7 @@ export const useFundsById = (fundIds = DEFAULT_VALUE, options = {}) => {
 
   const {
     data = {},
+    isFetching,
     isLoading,
   } = useQuery(
     [namespace, fundIds],
@@ -45,6 +46,7 @@ export const useFundsById = (fundIds = DEFAULT_VALUE, options = {}) => {
   );
 
   return ({
+    isFetching,
     isLoading,
     funds: data?.funds || DEFAULT_VALUE,
     totalRecords: data?.totalRecords,

--- a/src/components/POLine/hooks/useIsFundsRestrictedByLocationIds/useIsFundsRestrictedByLocationIds.js
+++ b/src/components/POLine/hooks/useIsFundsRestrictedByLocationIds/useIsFundsRestrictedByLocationIds.js
@@ -27,7 +27,7 @@ export const useIsFundsRestrictedByLocationIds = (line) => {
   }, [line]);
 
   const {
-    isLoading: isHoldingsLoading,
+    isFetching: isHoldingsFetching,
     holdings,
   } = useInstanceHoldingsQuery(line?.instanceId, { consortium: isCentralOrderingEnabled });
 
@@ -40,9 +40,10 @@ export const useIsFundsRestrictedByLocationIds = (line) => {
     return new Set([...locationIdsProp, ...permanentLocationIds]);
   }, [holdingIds, holdings, locationIdsProp]);
 
-  const { funds, isLoading: isFundsLoading } = useFundsById(fundIds, {
-    enabled: !isHoldingsLoading,
-  });
+  const {
+    funds,
+    isFetching: isFundsFetching,
+  } = useFundsById(fundIds, { enabled: !isHoldingsFetching });
 
   const locationsRestrictedByFunds = useMemo(() => {
     return funds
@@ -57,15 +58,15 @@ export const useIsFundsRestrictedByLocationIds = (line) => {
   }, [locationsRestrictedByFunds, locationIdsSet]);
 
   const hasLocationRestrictedFund = useMemo(() => {
-    if (!isHoldingsLoading && !isFundsLoading && locationsRestrictedByFunds.length) {
+    if (!isHoldingsFetching && !isFundsFetching && locationsRestrictedByFunds.length) {
       return !isFundNotRestricted();
     }
 
     return false;
-  }, [locationsRestrictedByFunds, isFundNotRestricted, isFundsLoading, isHoldingsLoading]);
+  }, [locationsRestrictedByFunds, isFundNotRestricted, isFundsFetching, isHoldingsFetching]);
 
   return ({
-    isLoading: isHoldingsLoading || isFundsLoading,
+    isLoading: isHoldingsFetching || isFundsFetching,
     hasLocationRestrictedFund,
   });
 };


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1420

When opening an order, if the configuration allows PO Lines to create holdings, the corresponding instance updates the response from the `holdings-storage/holdings` or `search/consortium/holdings` endpoint by including the newly created holding.
The `useIsFundsRestrictedByLocationIds` hook relies on the data from these endpoints and skips validation for restricted locations while its internal state is `isLoading`.
However, since `react-query` caches the data, the `isLoading` flag is set to `false` after the initial fetch, meaning that on subsequent calls, the hook may proceed with outdated data while new data is still being fetched — resulting in a false error message due to the mismatch.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Replace the check delay condition from `isLoading` to `isFetching` to ensure that validation is postponed until fresh data is actually received.
* Move the "restricted by funds" validation logic to the PO Line view level, as the current hook is invoked in an inappropriate context and may lead to incorrect behavior.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/c5f55377-2bcc-49f8-83d3-5fb1d7bbe1fd


<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
