### PR TITLE
UIOR-1514 Improve error message for order prefix and suffix name in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Implement PO number validation handler. Refs UIOR-1507.
 * Add translation for the `thereAreRequestsOnItem` error code. Refs UIOR-1498.
 * Translate static values. Refs UIOR-1518.
+* Improve error message for order prefix and suffix name in settings. Refs UIOR-1514.
 
 ## [8.0.5](https://github.com/folio-org/ui-orders/tree/v8.0.5) (2025-06-30)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v8.0.4...v8.0.5)

--- a/src/settings/utils.js
+++ b/src/settings/utils.js
@@ -9,12 +9,18 @@ import {
 import { Checkbox } from '@folio/stripes/components';
 
 const NAME_REGEXP = new RegExp(/[^a-zA-Z\d]|^.{8,}$/);
+const PREXIS_OR_SUFFIX_MAX_LENGTH = 8;
 
 export const validateName = (name) => {
   if (!name?.match(NAME_REGEXP)) return {};
 
   return {
-    name: <FormattedMessage id="ui-orders.settings.poNumber.nameValidation" />,
+    name: (
+      <FormattedMessage
+        id="ui-orders.settings.poNumber.validation.prefixOrSuffixPatternMismatch"
+        values={{ count: PREXIS_OR_SUFFIX_MAX_LENGTH }}
+      />
+    ),
   };
 };
 

--- a/src/settings/utils.test.js
+++ b/src/settings/utils.test.js
@@ -91,7 +91,10 @@ describe('validateName', () => {
     const name = 'suf0c966bd2';
     const actual = validateName(name);
     const expected = (
-      <FormattedMessage id="ui-orders.settings.poNumber.nameValidation" />
+      <FormattedMessage
+        id="ui-orders.settings.poNumber.validation.prefixOrSuffixPatternMismatch"
+        values={{ count: 8 }}
+      />
     );
 
     expect(actual.name).toEqual(expected);
@@ -119,7 +122,10 @@ describe('validateSuffixName', () => {
     };
     const actual = validateSuffixName(props);
     const expected = (
-      <FormattedMessage id="ui-orders.settings.poNumber.nameValidation" />
+      <FormattedMessage
+        id="ui-orders.settings.poNumber.validation.prefixOrSuffixPatternMismatch"
+        values={{ count: 8 }}
+      />
     );
 
     expect(actual.name).toEqual(expected);
@@ -147,7 +153,10 @@ describe('validatePrefixName', () => {
     };
     const actual = validatePrefixName(props);
     const expected = (
-      <FormattedMessage id="ui-orders.settings.poNumber.nameValidation" />
+      <FormattedMessage
+        id="ui-orders.settings.poNumber.validation.prefixOrSuffixPatternMismatch"
+        values={{ count: 8 }}
+      />
     );
 
     expect(actual.name).toEqual(expected);

--- a/translations/ui-orders/en.json
+++ b/translations/ui-orders/en.json
@@ -881,6 +881,7 @@
   "settings.poNumber.suffix.deleteEntry": "Delete suffix",
   "settings.poNumber.suffix.termDeleted": "The suffix <b>{term}</b> was successfully <b>deleted</b>",
   "settings.poNumber.suffix.termWillBeDeleted": "The suffix <b>{term}</b> will be <b>deleted.</b>",
+  "settings.poNumber.validation.prefixOrSuffixPatternMismatch": "Name must be less than {count, number} alphanumeric characters",
   "settings.poNumber.nameValidation": "Name is not valid",
   "settings.poNumber": "Purchase order number",
   "settings.saveBtn": "Save",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1514

When creating or editing the prefix or suffix for PO numbers in settings, when the prefix or suffix is too long, the error message presented is vague and uninformative.

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/302d2235-2033-4088-a6eb-b6d92e129f9e

