### PR TITLE
UIOR-1552 Fix the `budgetExpenseClassNotFound` error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.1.0 (IN PROGRESS)
 
+* Fix the `budgetExpenseClassNotFound` error handling. Refs UIOR-1552.
+
 ## [9.0.4](https://github.com/folio-org/ui-orders/tree/v9.0.4) (2026-05-26)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v9.0.3...v9.0.4)
 

--- a/src/components/Utils/order/handleErrorsStrategies/noExpenseClassesStrategy.js
+++ b/src/components/Utils/order/handleErrorsStrategies/noExpenseClassesStrategy.js
@@ -1,10 +1,11 @@
 export const noExpenseClassesStrategy = ({ callout }) => {
   const handle = (errorsContainer) => {
-    const fundCode = errorsContainer.getError().getParameter('fundCode');
-    const expenseClassName = errorsContainer.getError().getParameter('expenseClassName');
+    const error = errorsContainer.getError();
+    const fundCode = error.getParameter('fundCode');
+    const expenseClassName = error.getParameter('expenseClassName');
 
     callout.sendCallout({
-      messageId: `ui-orders.errors.${errorsContainer.code}`,
+      messageId: `ui-orders.errors.${error.code}`,
       type: 'error',
       values: { fundCode, expenseClassName },
     });


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/UIOR-1552

## Screenshot
<img width="1913" height="1074" alt="Screenshot 2026-05-28 at 13 00 20" src="https://github.com/user-attachments/assets/02a0b2a8-846d-4231-aff0-e514979dbf7e" />
