### PR TITLE
UIOR-1519 *BREAKING* Update CQL queries to use the new indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change history for ui-orders
 
-## 9.1.0 (IN PROGRESS)
+## 10.0.0 (IN PROGRESS)
 
 * Fix the `budgetExpenseClassNotFound` error handling. Refs UIOR-1552.
-* Update CQL queries to use the new indices. Refs UIOR-1519.
+* *BREAKING* Update CQL queries to use the new indices. Refs UIOR-1519.
 
 ## [9.0.4](https://github.com/folio-org/ui-orders/tree/v9.0.4) (2026-05-26)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v9.0.3...v9.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 9.1.0 (IN PROGRESS)
 
 * Fix the `budgetExpenseClassNotFound` error handling. Refs UIOR-1552.
+* Update CQL queries to use the new indices. Refs UIOR-1519.
 
 ## [9.0.4](https://github.com/folio-org/ui-orders/tree/v9.0.4) (2026-05-26)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v9.0.3...v9.0.4)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/orders",
-  "version": "9.0.4",
+  "version": "10.0.0",
   "description": "Description for orders",
   "main": "src/index.js",
   "repository": "",

--- a/package.json
+++ b/package.json
@@ -587,8 +587,8 @@
     "sinon": "^7.0.0"
   },
   "dependencies": {
-    "@folio/plugin-find-po-line": "^6.1.1",
-    "@folio/stripes-acq-components": "~7.1.0",
+    "@folio/plugin-find-po-line": "^7.0.0",
+    "@folio/stripes-acq-components": "~7.2.0",
     "@folio/stripes-template-editor": "^3.2.0",
     "classnames": "^2.2.5",
     "dompurify": "^3.0.9",

--- a/src/OrdersList/OrdersListSearchConfig.js
+++ b/src/OrdersList/OrdersListSearchConfig.js
@@ -22,7 +22,7 @@ const customSearchMap = {
 function getCqlQuery(query, qindex, dateFormat, customField) {
   return customField?.type === CUSTOM_FIELDS_TYPES.DATE_PICKER
     ? searchByDate(query, dateFormat)
-    : customSearchMap[qindex]?.(query, dateFormat) || `*${query}*`;
+    : customSearchMap[qindex]?.(query, dateFormat) || `${query}`;
 }
 
 const getKeywordQuery = (query, dateFormat, customFields) => {
@@ -51,7 +51,7 @@ export function makeSearchQuery(dateFormat, customFields) {
 
       const cqlQuery = getCqlQuery(query, qindex, dateFormat, customField);
 
-      return `(${qindex}==${cqlQuery})`;
+      return `${qindex}=="${cqlQuery}"`;
     }
 
     return getKeywordQuery(query, dateFormat, customFields);

--- a/src/OrdersList/OrdersListSearchConfig.test.js
+++ b/src/OrdersList/OrdersListSearchConfig.test.js
@@ -8,39 +8,39 @@ describe('makeSearchQuery', () => {
   it('should return query without qindex', () => {
     const query = makeSearchQuery()('query');
 
-    expect(query).toBe(`metadata.createdDate=="Invalid Date*" or dateOrdered=="Invalid Date*" or poNumber=="*${QUERY}*"`);
+    expect(query).toBe(`metadata.createdDate=="Invalid Date*" or dateOrdered=="Invalid Date*" or poNumber=="${QUERY}"`);
   });
 
   it('should return query with qindex', () => {
     const query = makeSearchQuery()('query', 'qindex');
 
-    expect(query).toBe(`(qindex==*${QUERY}*)`);
+    expect(query).toBe(`qindex=="${QUERY}"`);
   });
 
   it('should return correct query without custom fields', () => {
     const query = makeSearchQuery()(QUERY, 'qindex');
 
-    expect(query).toBe(`(qindex==*${QUERY}*)`);
+    expect(query).toBe(`qindex=="${QUERY}"`);
   });
 
   it('should return correct query for custom field type DATE_PICKER', () => {
     const query = makeSearchQuery('MM/DD/YYYY', CUSTOM_FIELDS_FIXTURE)('03/24/2020', 'customFields.datepicker');
 
-    expect(query).toBe('(customFields.datepicker==2020-03-24*)');
+    expect(query).toBe('customFields.datepicker=="2020-03-24*"');
   });
 
   it('should return correct query for custom field type TEXTBOX_SHORT', () => {
     const query = makeSearchQuery(null, CUSTOM_FIELDS_FIXTURE)(QUERY, 'customFields.shorttext');
 
-    expect(query).toBe(`(customFields.shorttext==*${QUERY}*)`);
+    expect(query).toBe(`customFields.shorttext=="${QUERY}"`);
   });
 
   it('should return keyword query with custom fields', () => {
     const query = makeSearchQuery(null, CUSTOM_FIELDS_FIXTURE)(QUERY);
 
     expect(query).toBe(
-      `metadata.createdDate=="Invalid Date*" or dateOrdered=="Invalid Date*" or poNumber=="*${QUERY}*" or ` +
-      `customFields.datepicker=="Invalid Date*" or customFields.longtext=="*${QUERY}*" or customFields.shorttext=="*${QUERY}*"`,
+      `metadata.createdDate=="Invalid Date*" or dateOrdered=="Invalid Date*" or poNumber=="${QUERY}" or ` +
+      `customFields.datepicker=="Invalid Date*" or customFields.longtext=="${QUERY}" or customFields.shorttext=="${QUERY}"`,
     );
   });
 });

--- a/src/OrdersList/hooks/useBuildQuery/useBuildQuery.js
+++ b/src/OrdersList/hooks/useBuildQuery/useBuildQuery.js
@@ -33,8 +33,8 @@ export function useBuildQuery(customFields) {
         },
         [FILTERS.TAGS]: buildMultiSelectionCqlQuery.bind(null, FILTERS.TAGS),
         [FILTERS.ACQUISITIONS_UNIT]: buildMultiSelectionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
-        [FILTERS.FUND_CODE]: buildRelationModifierQuery.bind(null, FILTERS.FUND_CODE, 'fundId'),
-        [FILTERS.RENEWAL_REVIEW_PERIOD]: (filterValue) => `${FILTERS.RENEWAL_REVIEW_PERIOD} =/number "${filterValue}"`,
+        [FILTERS.FUND_CODE]: buildRelationModifierQuery.bind(null, FILTERS.FUND_CODE, '@fundId'),
+        [FILTERS.RENEWAL_REVIEW_PERIOD]: buildRelationModifierQuery.bind(null, FILTERS.RENEWAL_REVIEW_PERIOD, 'number'),
         ...customFieldsFilterMap,
       },
     )(queryParams, options);

--- a/src/OrdersList/hooks/useBuildQuery/useBuildQuery.js
+++ b/src/OrdersList/hooks/useBuildQuery/useBuildQuery.js
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 
 import {
-  buildArrayFieldQuery,
   buildDateRangeQuery,
   buildDateTimeRangeQuery,
+  buildMultiSelectionCqlQuery,
   getCustomFieldsFilterMap,
   makeQueryBuilder,
   ORDER_STATUSES,
@@ -31,9 +31,10 @@ export function useBuildQuery(customFields) {
         [FILTERS.CLOSE_REASON]: (filterValue) => {
           return `(${FILTERS.CLOSE_REASON}=="${filterValue}" and ${FILTERS.STATUS}=="${ORDER_STATUSES.closed}")`;
         },
-        [FILTERS.TAGS]: buildArrayFieldQuery.bind(null, [FILTERS.TAGS]),
-        [FILTERS.ACQUISITIONS_UNIT]: buildArrayFieldQuery.bind(null, [FILTERS.ACQUISITIONS_UNIT]),
+        [FILTERS.TAGS]: buildMultiSelectionCqlQuery.bind(null, FILTERS.TAGS),
+        [FILTERS.ACQUISITIONS_UNIT]: buildMultiSelectionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
         [FILTERS.FUND_CODE]: buildRelationModifierQuery.bind(null, FILTERS.FUND_CODE, 'fundId'),
+        [FILTERS.RENEWAL_REVIEW_PERIOD]: (filterValue) => `${FILTERS.RENEWAL_REVIEW_PERIOD} =/number "${filterValue}"`,
         ...customFieldsFilterMap,
       },
     )(queryParams, options);

--- a/src/OrdersList/hooks/useBuildQuery/useBuildQuery.js
+++ b/src/OrdersList/hooks/useBuildQuery/useBuildQuery.js
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import {
   buildDateRangeQuery,
   buildDateTimeRangeQuery,
-  buildMultiSelectionCqlQuery,
+  buildMultiOptionCqlQuery,
   getCustomFieldsFilterMap,
   makeQueryBuilder,
   ORDER_STATUSES,
@@ -31,8 +31,8 @@ export function useBuildQuery(customFields) {
         [FILTERS.CLOSE_REASON]: (filterValue) => {
           return `(${FILTERS.CLOSE_REASON}=="${filterValue}" and ${FILTERS.STATUS}=="${ORDER_STATUSES.closed}")`;
         },
-        [FILTERS.TAGS]: buildMultiSelectionCqlQuery.bind(null, FILTERS.TAGS),
-        [FILTERS.ACQUISITIONS_UNIT]: buildMultiSelectionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
+        [FILTERS.TAGS]: buildMultiOptionCqlQuery.bind(null, FILTERS.TAGS),
+        [FILTERS.ACQUISITIONS_UNIT]: buildMultiOptionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
         [FILTERS.FUND_CODE]: buildRelationModifierQuery.bind(null, FILTERS.FUND_CODE, '@fundId'),
         [FILTERS.RENEWAL_REVIEW_PERIOD]: buildRelationModifierQuery.bind(null, FILTERS.RENEWAL_REVIEW_PERIOD, 'number'),
         ...customFieldsFilterMap,

--- a/src/common/hooks/useExportHistory/useExportHistory.js
+++ b/src/common/hooks/useExportHistory/useExportHistory.js
@@ -5,14 +5,17 @@ import {
   useOkapiKy,
   useNamespace,
 } from '@folio/stripes/core';
-import { batchRequest } from '@folio/stripes-acq-components';
+import {
+  batchRequest,
+  buildMultiOptionCqlQuery,
+} from '@folio/stripes-acq-components';
 
 import { EXPORT_HISTORY_API } from '../../../components/Utils/api';
 
 const buildQueryByPoLineIds = (poLineIds) => {
-  const query = poLineIds.map(id => `"*\\"${id}\\"*"`).join(' or ');
+  const cql = buildMultiOptionCqlQuery('exportedPoLineIds', poLineIds);
 
-  return `exportedPoLineIds==(${query}) sortby exportDate/sort.descending`;
+  return `${cql} sortby exportDate/sort.descending`;
 };
 
 export const useExportHistory = (poLineIds = []) => {

--- a/src/common/hooks/useLinesLimit/useLinesLimit.js
+++ b/src/common/hooks/useLinesLimit/useLinesLimit.js
@@ -16,7 +16,7 @@ export const useLinesLimit = (enabled = true) => {
   const [namespace] = useNamespace({ key: 'order-lines-limit' });
 
   const searchParams = {
-    query: `key=${CONFIG_LINES_LIMIT}`,
+    query: `key=="${CONFIG_LINES_LIMIT}"`,
   };
 
   const { isLoading, data = {} } = useQuery(

--- a/src/common/hooks/useOpenOrderSettings/useOpenOrderSettings.js
+++ b/src/common/hooks/useOpenOrderSettings/useOpenOrderSettings.js
@@ -21,7 +21,7 @@ export const useOpenOrderSettings = (options = {}) => {
   const [namespace] = useNamespace({ key: 'open-order-settings' });
 
   const searchParams = {
-    query: `key=${CONFIG_OPEN_ORDER}`,
+    query: `key=="${CONFIG_OPEN_ORDER}"`,
   };
 
   const { isFetching, data } = useQuery(

--- a/src/common/utils/buildRelationModifierQuery.js
+++ b/src/common/utils/buildRelationModifierQuery.js
@@ -1,3 +1,7 @@
+import { buildMultiSelectionCqlQuery } from '@folio/stripes-acq-components';
+
 export const buildRelationModifierQuery = (filterKey, relationModifier, filterValue) => {
-  return `${filterKey}=/@${relationModifier} (${Array.isArray(filterValue) ? filterValue.join(' or ') : filterValue})`;
+  const modifiers = [{ name: relationModifier }];
+
+  return buildMultiSelectionCqlQuery(filterKey, filterValue, { modifiers });
 };

--- a/src/common/utils/buildRelationModifierQuery.js
+++ b/src/common/utils/buildRelationModifierQuery.js
@@ -1,7 +1,7 @@
-import { buildMultiSelectionCqlQuery } from '@folio/stripes-acq-components';
+import { buildMultiOptionCqlQuery } from '@folio/stripes-acq-components';
 
 export const buildRelationModifierQuery = (filterKey, relationModifier, filterValue) => {
   const modifiers = [{ name: relationModifier }];
 
-  return buildMultiSelectionCqlQuery(filterKey, filterValue, { modifiers });
+  return buildMultiOptionCqlQuery(filterKey, filterValue, { modifiers });
 };

--- a/src/common/utils/buildRelationModifierQuery.test.js
+++ b/src/common/utils/buildRelationModifierQuery.test.js
@@ -5,9 +5,9 @@ import { buildRelationModifierQuery } from './buildRelationModifierQuery';
 describe('buildRelationModifierQuery', () => {
   it('should build query with single filter value', () => {
     const filterKey = 'status';
-    const relationModifier = 'eq';
+    const relationModifier = '@eq';
     const filterValue = 'active';
-    const expectedQuery = 'status=/@eq (active)';
+    const expectedQuery = 'status =/@eq "active"';
 
     const result = buildRelationModifierQuery(filterKey, relationModifier, filterValue);
 
@@ -16,9 +16,9 @@ describe('buildRelationModifierQuery', () => {
 
   it('should build query with multiple filter values', () => {
     const filterKey = 'status';
-    const relationModifier = 'eq';
+    const relationModifier = '@eq';
     const filterValue = ['active', 'inactive'];
-    const expectedQuery = 'status=/@eq (active or inactive)';
+    const expectedQuery = 'status =/@eq ("active" OR "inactive")';
 
     const result = buildRelationModifierQuery(filterKey, relationModifier, filterValue);
 

--- a/src/components/Utils/resources.js
+++ b/src/components/Utils/resources.js
@@ -102,7 +102,7 @@ export const LINES_LIMIT = {
   path: ORDERS_STORAGE_SETTINGS_API,
   GET: {
     params: {
-      query: `key=${CONFIG_LINES_LIMIT}`,
+      query: `key=="${CONFIG_LINES_LIMIT}"`,
     },
   },
 };
@@ -133,7 +133,7 @@ export const CREATE_INVENTORY = {
   records: 'settings',
   GET: {
     params: {
-      query: `key=${CONFIG_CREATE_INVENTORY}`,
+      query: `key=="${CONFIG_CREATE_INVENTORY}"`,
     },
   },
 };
@@ -144,7 +144,7 @@ export const ORDER_NUMBER_SETTING = {
   records: 'settings',
   GET: {
     params: {
-      query: `key=${CONFIG_ORDER_NUMBER}`,
+      query: `key=="${CONFIG_ORDER_NUMBER}"`,
     },
   },
 };
@@ -155,7 +155,7 @@ export const APPROVALS_SETTING = {
   records: 'settings',
   GET: {
     params: {
-      query: `key=${CONFIG_APPROVALS}`,
+      query: `key=="${CONFIG_APPROVALS}"`,
     },
   },
 };
@@ -223,7 +223,7 @@ export const OPEN_ORDER_SETTING = {
   records: 'settings',
   GET: {
     params: {
-      query: `key=${CONFIG_OPEN_ORDER}`,
+      query: `key=="${CONFIG_OPEN_ORDER}"`,
     },
   },
 };

--- a/src/settings/POLinesLimit.js
+++ b/src/settings/POLinesLimit.js
@@ -77,7 +77,7 @@ POLinesLimit.manifest = Object.freeze({
     path: ORDERS_STORAGE_SETTINGS_API,
     GET: {
       params: {
-        query: `key=${CONFIG_LINES_LIMIT}`,
+        query: `key=="${CONFIG_LINES_LIMIT}"`,
       },
     },
   },

--- a/src/settings/RoutingAddress/hooks/useRoutingAddressSettings/useRoutingAddressSettings.js
+++ b/src/settings/RoutingAddress/hooks/useRoutingAddressSettings/useRoutingAddressSettings.js
@@ -14,7 +14,7 @@ export const useRoutingAddressSettings = (options = {}) => {
 
   const searchParams = {
     limit: 1,
-    query: `key=${ROUTING_USER_ADDRESS_TYPE_ID}`,
+    query: `key=="${ROUTING_USER_ADDRESS_TYPE_ID}"`,
   };
 
   const {

--- a/src/settings/hooks/useDefaultReceivingSearchSettings/useDefaultReceivingSearchSettings.js
+++ b/src/settings/hooks/useDefaultReceivingSearchSettings/useDefaultReceivingSearchSettings.js
@@ -14,7 +14,7 @@ export const useDefaultReceivingSearchSettings = (options = {}) => {
 
   const searchParams = {
     limit: 1,
-    query: `key=${CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH_SETTINGS_KEY}`,
+    query: `key=="${CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH_SETTINGS_KEY}"`,
   };
 
   const {

--- a/src/settings/hooks/useNumberGeneratorOptions/useNumberGeneratorOptions.js
+++ b/src/settings/hooks/useNumberGeneratorOptions/useNumberGeneratorOptions.js
@@ -14,7 +14,7 @@ export const useNumberGeneratorOptions = () => {
 
   const searchParams = {
     limit: 1,
-    query: `key=${NUMBER_GENERATOR_SETTINGS_KEY}`,
+    query: `key=="${NUMBER_GENERATOR_SETTINGS_KEY}"`,
   };
 
   const {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1519

Requires https://github.com/folio-org/stripes-acq-components/pull/951

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

- Use `buildMultiOptionCqlQuery` to update CQL with relation modifiers;
- Remove wrapping the filter value in wildcards.
- Update tests.