### PR TITLE
UIOR-1565 Use `permanentLoanType` as a fallback for the loan type in the item list format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix the `budgetExpenseClassNotFound` error handling. Refs UIOR-1552.
 * *BREAKING* Update CQL queries to use the new indices. Refs UIOR-1519.
 * Update the "Ongoing order information" for PO Line to define multi-year payments. Refs UIOR-1528.
+* Use `permanentLoanType` as a fallback for the loan type in the item list format. Refs UIOR-1565.
 
 ## [9.0.4](https://github.com/folio-org/ui-orders/tree/v9.0.4) (2026-05-26)
 [Full Changelog](https://github.com/folio-org/ui-orders/compare/v9.0.3...v9.0.4)

--- a/src/components/POLine/ChangeInstanceConnection/hooks/useRelatedItemsMCL/useRelatedItemsMCL.js
+++ b/src/components/POLine/ChangeInstanceConnection/hooks/useRelatedItemsMCL/useRelatedItemsMCL.js
@@ -37,7 +37,11 @@ export const useRelatedItemsMCL = () => {
       [ITEMS_COLUMN_NAMES.status]: item => item.status?.name || <NoValue />,
       [ITEMS_COLUMN_NAMES.copyNumber]: item => item.copyNumber || <NoValue />,
       [ITEMS_COLUMN_NAMES.materialType]: item => item.materialType?.name || <NoValue />,
-      [ITEMS_COLUMN_NAMES.loanType]: item => item.temporaryLoanType?.name || <NoValue />,
+      [ITEMS_COLUMN_NAMES.loanType]: item => (
+        item.temporaryLoanType?.name
+        || item.permanentLoanType?.name
+        || <NoValue />
+      ),
       [ITEMS_COLUMN_NAMES.tenantId]: item => tenantsMap[item.tenantId]?.name || <NoValue />,
       [ITEMS_COLUMN_NAMES.effectiveLocation]: item => item.effectiveLocation?.name || <NoValue />,
       [ITEMS_COLUMN_NAMES.enumeration]: item => item.enumeration || <NoValue />,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIOR-1565

Permanent loan type is not populated from the item record.