### PR TITLE
UIOR-1569: Correct refresh of prefix and suffix fields

### DIFF
--- a/src/common/POFields/FieldPrefix.js
+++ b/src/common/POFields/FieldPrefix.js
@@ -11,6 +11,7 @@ import { PO_FORM_FIELDS } from '../constants';
 const FieldPrefix = ({
   isNonInteractive = false,
   prefixes,
+  shouldValidate,
   ...rest
 }) => {
   return (
@@ -19,7 +20,7 @@ const FieldPrefix = ({
       isNonInteractive={isNonInteractive}
       label={<FormattedMessage id="ui-orders.orderDetails.orderNumberPrefix" />}
       name={PO_FORM_FIELDS.poNumberPrefix}
-      validateFields={[PO_FORM_FIELDS.poNumber]}
+      validateFields={shouldValidate ? [PO_FORM_FIELDS.poNumber] : []}
       {...rest}
     />
   );

--- a/src/common/POFields/FieldPrefix.test.js
+++ b/src/common/POFields/FieldPrefix.test.js
@@ -2,7 +2,20 @@ import { Form } from 'react-final-form';
 
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
+import { PO_FORM_FIELDS } from '../constants';
 import FieldPrefix from './FieldPrefix';
+
+const mockFieldSelectFinal = jest.fn(({ label }) => label);
+
+jest.mock('@folio/stripes-acq-components', () => {
+  const React = jest.requireActual('react');
+  const PropTypes = jest.requireActual('prop-types');
+
+  return {
+    FieldSelectFinal: (props) => mockFieldSelectFinal(props),
+    fieldSelectOptionsShape: PropTypes.arrayOf(PropTypes.shape({})),
+  };
+});
 
 const defaultProps = {
   prefixes: [],
@@ -21,9 +34,29 @@ const renderFieldPrefix = (props = {}) => render(
 );
 
 describe('FieldPrefix', () => {
-  it('should render \'prefix\' field', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the prefix field', () => {
     renderFieldPrefix();
 
     expect(screen.getByText('ui-orders.orderDetails.orderNumberPrefix')).toBeInTheDocument();
+  });
+
+  it('should not validate PO number when shouldValidate is false', () => {
+    renderFieldPrefix({ shouldValidate: false });
+
+    expect(mockFieldSelectFinal).toHaveBeenCalledWith(expect.objectContaining({
+      validateFields: [],
+    }));
+  });
+
+  it('should validate PO number when shouldValidate is true', () => {
+    renderFieldPrefix({ shouldValidate: true });
+
+    expect(mockFieldSelectFinal).toHaveBeenCalledWith(expect.objectContaining({
+      validateFields: [PO_FORM_FIELDS.poNumber],
+    }));
   });
 });

--- a/src/common/POFields/FieldSuffix.js
+++ b/src/common/POFields/FieldSuffix.js
@@ -11,6 +11,7 @@ import { PO_FORM_FIELDS } from '../constants';
 const FieldSuffix = ({
   isNonInteractive = false,
   suffixes,
+  shouldValidate,
   ...rest
 }) => {
   return (
@@ -19,7 +20,7 @@ const FieldSuffix = ({
       isNonInteractive={isNonInteractive}
       label={<FormattedMessage id="ui-orders.orderDetails.orderNumberSuffix" />}
       name={PO_FORM_FIELDS.poNumberSuffix}
-      validateFields={[PO_FORM_FIELDS.poNumber]}
+      validateFields={shouldValidate ? [PO_FORM_FIELDS.poNumber] : []}
       {...rest}
     />
   );

--- a/src/common/POFields/FieldSuffix.test.js
+++ b/src/common/POFields/FieldSuffix.test.js
@@ -2,7 +2,19 @@ import { Form } from 'react-final-form';
 
 import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
+import { PO_FORM_FIELDS } from '../constants';
 import FieldSuffix from './FieldSuffix';
+
+const mockFieldSelectFinal = jest.fn(({ label }) => label);
+
+jest.mock('@folio/stripes-acq-components', () => {
+  const PropTypes = jest.requireActual('prop-types');
+
+  return {
+    FieldSelectFinal: (props) => mockFieldSelectFinal(props),
+    fieldSelectOptionsShape: PropTypes.arrayOf(PropTypes.shape({})),
+  };
+});
 
 const defaultProps = {
   suffixes: [],
@@ -21,9 +33,29 @@ const renderFieldSuffix = (props = {}) => render(
 );
 
 describe('FieldSuffix', () => {
-  it('should render \'suffix\' field', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the suffix field', () => {
     renderFieldSuffix();
 
     expect(screen.getByText('ui-orders.orderDetails.orderNumberSuffix')).toBeInTheDocument();
+  });
+
+  it('should not validate PO number when shouldValidate is false', () => {
+    renderFieldSuffix({ shouldValidate: false });
+
+    expect(mockFieldSelectFinal).toHaveBeenCalledWith(expect.objectContaining({
+      validateFields: [],
+    }));
+  });
+
+  it('should validate PO number when shouldValidate is true', () => {
+    renderFieldSuffix({ shouldValidate: true });
+
+    expect(mockFieldSelectFinal).toHaveBeenCalledWith(expect.objectContaining({
+      validateFields: [PO_FORM_FIELDS.poNumber],
+    }));
   });
 });

--- a/src/components/PurchaseOrder/PODetails/PODetailsForm.js
+++ b/src/components/PurchaseOrder/PODetails/PODetailsForm.js
@@ -96,6 +96,7 @@ class PODetailsForm extends Component {
               <FieldPrefix
                 isNonInteractive={isPostPendingOrder}
                 prefixes={prefixesSetting}
+                shouldValidate={canUserEditOrderNumber}
               />
             </Col>
           </IfFieldVisible>
@@ -120,6 +121,7 @@ class PODetailsForm extends Component {
               <FieldSuffix
                 isNonInteractive={isPostPendingOrder}
                 suffixes={suffixesSetting}
+                shouldValidate={canUserEditOrderNumber}
               />
             </Col>
           </IfFieldVisible>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

https://folio-org.atlassian.net/browse/UIOR-1569

This is a bugfix for the following problem: Prefix and suffix do not correctly refresh on selection in the create and edit of a Purchase Order.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

How did we solve this? Well, `FieldPrefix` and `FieldSuffix` contained broken validation logic, s.t. we could run into cases where we need to validate fields that aren't present. To fix that, we put the condition `shouldRevalidatePoNumber` in place, taking care of that cases. That makes sure we only run the validation when `poNumber` was mounted and is actually present, s.t. it can really be used for validation.